### PR TITLE
Enhance service request flow with CTAs and detailed form page

### DIFF
--- a/src/app/services/ServicesClient.tsx
+++ b/src/app/services/ServicesClient.tsx
@@ -142,22 +142,27 @@ export default function ServicesClient() {
                 {section.services.map((s, i) => (
                   <div
                     key={i}
-                    onClick={() => router.push(`/services/${s.slug}?lang=${locale}`)}
-                    className="flex-shrink-0 w-[250px] rounded-lg overflow-hidden shadow hover:shadow-md transition bg-white cursor-pointer"
+                    className="relative flex-shrink-0 w-[250px] rounded-lg overflow-hidden shadow hover:shadow-md transition bg-white"
                   >
-                  <Image
-                    src={s.image}
-                    alt={s.name}
-                    width={250}
-                    height={160}
-                    className="w-full h-36 sm:h-40 object-cover"
-                  />
-                  <div className="px-3 py-2">
-                    <h3 className="font-medium text-sm truncate">{s.name}</h3>
-                    <p className="text-xs text-gray-600">⭐ {s.rating} • {s.time}</p>
+                    <Image
+                      src={s.image}
+                      alt={s.name}
+                      width={250}
+                      height={160}
+                      className="w-full h-36 sm:h-40 object-cover"
+                    />
+                    <div className="px-3 py-2">
+                      <h3 className="font-medium text-sm truncate">{s.name}</h3>
+                      <p className="text-xs text-gray-600">⭐ {s.rating} • {s.time}</p>
+                      <button
+                        onClick={() => router.push(`/services/${s.slug}?lang=${locale}`)}
+                        className="mt-2 inline-block bg-black text-white rounded-full px-3 py-1 text-xs hover:bg-gray-900"
+                      >
+                        {locale === 'es' ? 'Solicitar servicio' : 'Request Service'}
+                      </button>
+                    </div>
                   </div>
-                </div>
-              ))}
+                ))}
             </div>
           </div>
         ))}

--- a/src/app/services/[service]/ServiceFormClient.tsx
+++ b/src/app/services/[service]/ServiceFormClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
+import Image from 'next/image'
 import Navbar from '@/components/layout/Navbar'
 import Footer from '@/components/layout/Footer'
 
@@ -40,8 +41,8 @@ const translations = {
     cityPlaceholder: 'Localidad',
     message: 'Mensaje',
     messagePlaceholder: 'Escribe tu mensaje',
-    invoices: 'Facturas',
-    invoicesHint: 'Sube hasta 3 facturas (PDF o imagen)',
+    invoices: '¿Ya tienes otras ofertas? Sube hasta 3 facturas…',
+    invoicesHint: 'Archivos PDF o imagen',
     send: 'Enviar'
   },
   en: {
@@ -78,11 +79,78 @@ const translations = {
     cityPlaceholder: 'City',
     message: 'Message',
     messagePlaceholder: 'Write your message',
-    invoices: 'Invoices',
-    invoicesHint: 'Upload up to 3 invoices (PDF or image)',
+    invoices: 'Already have other offers? Upload up to 3 invoices.',
+    invoicesHint: 'PDF or image files',
     send: 'Send'
   }
 }
+
+const serviceInfo = {
+  seguridad: {
+    esName: 'Seguridad privada',
+    enName: 'Private Security',
+    esDesc: 'Protección integral para hogares y negocios.',
+    enDesc: 'Comprehensive protection for homes and businesses.',
+    image: '/images/services/security.jpg',
+    rating: '4.8'
+  },
+  limpieza: {
+    esName: 'Limpieza Profesional',
+    enName: 'Professional Cleaning',
+    esDesc: 'Servicios de limpieza detallados para cualquier espacio.',
+    enDesc: 'Detailed cleaning services for any space.',
+    image: '/images/services/cleaning.jpg',
+    rating: '4.7'
+  },
+  fumigacion: {
+    esName: 'Fumigación a domicilio',
+    enName: 'Home Fumigation',
+    esDesc: 'Eliminación de plagas con técnicas seguras.',
+    enDesc: 'Pest removal with safe techniques.',
+    image: '/images/services/fumigation.jpg',
+    rating: '4.6'
+  },
+  'mantenimiento-ascensores': {
+    esName: 'Mantenimiento de ascensores',
+    enName: 'Elevator Maintenance',
+    esDesc: 'Mantenimiento preventivo y correctivo de ascensores.',
+    enDesc: 'Preventive and corrective elevator maintenance.',
+    image: '/images/services/elevator_maintenance.jpg',
+    rating: '4.5'
+  },
+  escribania: {
+    esName: 'Escribanía',
+    enName: 'Notary Services',
+    esDesc: 'Gestiones notariales con profesionales matriculados.',
+    enDesc: 'Notarial procedures by licensed professionals.',
+    image: '/images/services/notary.jpg',
+    rating: '4.7'
+  },
+  'community-manager': {
+    esName: 'Community Manager',
+    enName: 'Community Manager',
+    esDesc: 'Gestión de redes sociales para tu marca.',
+    enDesc: 'Social media management for your brand.',
+    image: '/images/services/community.jpg',
+    rating: '4.5'
+  },
+  'traslados-ejecutivos': {
+    esName: 'Traslados Ejecutivos',
+    enName: 'Executive Transfers',
+    esDesc: 'Transporte ejecutivo cómodo y seguro.',
+    enDesc: 'Comfortable and safe executive transport.',
+    image: '/images/services/transfer.jpg',
+    rating: '4.8'
+  },
+  'salones-infantiles': {
+    esName: 'Salones Infantiles',
+    enName: 'Kids Party Venues',
+    esDesc: 'Espacios ideales para fiestas infantiles.',
+    enDesc: 'Ideal spaces for kids parties.',
+    image: '/images/services/kids-party.jpg',
+    rating: '4.6'
+  }
+} as const
 
 type Props = {
   service: string
@@ -118,9 +186,29 @@ export default function ServiceFormClient({ service }: Props) {
   const [mensaje, setMensaje] = useState('')
   const [sistemas, setSistemas] = useState<string[]>([])
   const [invoices, setInvoices] = useState<File[]>([])
+  const [submitted, setSubmitted] = useState(false)
 
   const isSeguridad = service.toLowerCase() === 'seguridad'
   const t = translations[locale]
+  type ServiceInfo = typeof serviceInfo[keyof typeof serviceInfo]
+  const info: ServiceInfo =
+    (serviceInfo as Record<string, ServiceInfo>)[service] || {
+      esName: service,
+      enName: service,
+      esDesc: '',
+      enDesc: '',
+      image: '',
+      rating: ''
+    }
+
+  useEffect(() => {
+    if (isSeguridad) {
+      const defaultOpt = translations[locale].sistemasOptions[0]
+      setSistemas([defaultOpt])
+    } else {
+      setSistemas([])
+    }
+  }, [isSeguridad, locale])
 
   const toggleSistema = (value: string) => {
     setSistemas(prev =>
@@ -148,6 +236,7 @@ export default function ServiceFormClient({ service }: Props) {
       mensaje,
       invoices
     })
+    setSubmitted(true)
   }
 
   const navT = {
@@ -172,162 +261,237 @@ export default function ServiceFormClient({ service }: Props) {
   }
 
   return (
-    <div className="min-h-screen bg-white text-gray-900 dark:bg-gray-950 dark:text-white flex flex-col">
+    <div className="min-h-screen flex flex-col bg-white text-gray-900 dark:bg-gray-950 dark:text-white">
       <Navbar locale={locale} toggleLocale={toggleLocale} t={navT} forceWhite />
-      <main className="flex-grow flex items-center justify-center px-4 pt-24 pb-12">
-        <form
-          onSubmit={handleSubmit}
-          className="w-full max-w-2xl bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-6 shadow-xl"
-        >
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <div>
-              <label className="block text-xs font-medium mb-1" htmlFor="nombre">
-                {t.name}
-              </label>
-              <input
-                id="nombre"
-                type="text"
-                placeholder={t.namePlaceholder}
-                value={nombre}
-                onChange={e => setNombre(e.target.value)}
-                className="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-800 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-black focus:border-black dark:focus:ring-white dark:focus:border-white hover:border-gray-400"
+      <main className="flex-grow pt-24 pb-12 px-4">
+        <nav className="mb-4 text-xs text-gray-600">
+          <button
+            onClick={() => router.push(`/services?lang=${locale}`)}
+            className="hover:underline"
+          >
+            {locale === 'es' ? 'Servicios' : 'Services'}
+          </button>
+          <span className="mx-1">→</span>
+          <span>{locale === 'es' ? info.esName : info.enName}</span>
+          <span className="mx-1">→</span>
+          <span className="font-medium">{locale === 'es' ? 'Solicitud' : 'Request'}</span>
+        </nav>
+        <ol className="flex items-center mb-6 text-xs text-gray-600">
+          <li className="flex items-center">
+            <span className="flex items-center justify-center h-6 w-6 rounded-full bg-gray-200 text-gray-600 mr-2">1</span>
+            {locale === 'es' ? 'Seleccionar servicio' : 'Select Service'}
+          </li>
+          <li className="flex-auto border-t border-gray-300 mx-2" />
+          <li className="flex items-center">
+            <span className="flex items-center justify-center h-6 w-6 rounded-full bg-black text-white mr-2">2</span>
+            {locale === 'es' ? 'Completar solicitud' : 'Fill Request'}
+          </li>
+          <li className="flex-auto border-t border-gray-300 mx-2" />
+          <li className="flex items-center">
+            <span className="flex items-center justify-center h-6 w-6 rounded-full bg-gray-200 text-gray-600 mr-2">3</span>
+            {locale === 'es' ? 'Confirmación' : 'Confirmation'}
+          </li>
+        </ol>
+        <div className="grid md:grid-cols-2 gap-8">
+          <div>
+            {info.image && (
+              <Image
+                src={info.image}
+                alt={locale === 'es' ? info.esName : info.enName}
+                width={600}
+                height={300}
+                className="w-full h-48 object-cover rounded-lg"
               />
-            </div>
-            <div>
-              <label className="block text-xs font-medium mb-1" htmlFor="email">
-                {t.email}
-              </label>
-              <input
-                id="email"
-                type="email"
-                placeholder={t.emailPlaceholder}
-                value={email}
-                onChange={e => setEmail(e.target.value)}
-                className="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-800 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-black focus:border-black dark:focus:ring-white dark:focus:border-white hover:border-gray-400"
-              />
-            </div>
-            <div>
-              <label className="block text-xs font-medium mb-1" htmlFor="telefono">
-                {t.phone}
-              </label>
-              <input
-                id="telefono"
-                type="tel"
-                placeholder={t.phonePlaceholder}
-                value={telefono}
-                onChange={e => setTelefono(e.target.value)}
-                className="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-800 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-black focus:border-black dark:focus:ring-white dark:focus:border-white hover:border-gray-400"
-              />
-            </div>
-            <div>
-              <label className="block text-xs font-medium mb-1" htmlFor="tipoPropiedad">
-                {t.propertyType}
-              </label>
-              <select
-                id="tipoPropiedad"
-                value={tipoPropiedad}
-                onChange={e => setTipoPropiedad(e.target.value)}
-                className="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-800 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-black focus:border-black dark:focus:ring-white dark:focus:border-white hover:border-gray-400"
-              >
-                <option value="">{t.propertyTypePlaceholder}</option>
-                {t.propertyTypes.map(pt => (
-                  <option key={pt} value={pt}>
-                    {pt}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div>
-              <label className="block text-xs font-medium mb-1" htmlFor="direccion">
-                {t.address}
-              </label>
-              <input
-                id="direccion"
-                type="text"
-                placeholder={t.addressPlaceholder}
-                value={direccion}
-                onChange={e => setDireccion(e.target.value)}
-                className="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-800 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-black focus:border-black dark:focus:ring-white dark:focus:border-white hover:border-gray-400"
-              />
-            </div>
-            <div>
-              <label className="block text-xs font-medium mb-1" htmlFor="localidad">
-                {t.city}
-              </label>
-              <input
-                id="localidad"
-                type="text"
-                placeholder={t.cityPlaceholder}
-                value={localidad}
-                onChange={e => setLocalidad(e.target.value)}
-                className="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-800 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-black focus:border-black dark:focus:ring-white dark:focus:border-white hover:border-gray-400"
-              />
-            </div>
-            {isSeguridad && (
-              <div className="sm:col-span-2">
-                <span className="block text-xs font-medium mb-1">{t.sistemasTitle}</span>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                  {t.sistemasOptions.map(opt => (
-                    <label
-                      key={opt}
-                      className="flex items-center space-x-2 rounded-md p-2 hover:bg-gray-50 dark:hover:bg-gray-800 transition"
-                    >
-                      <input
-                        type="checkbox"
-                        checked={sistemas.includes(opt)}
-                        onChange={() => toggleSistema(opt)}
-                        className="h-4 w-4 text-black dark:text-white focus:ring-black dark:focus:ring-white"
-                      />
-                      <span className="text-sm">{opt}</span>
-                    </label>
-                  ))}
-                </div>
-              </div>
             )}
-            <div className="sm:col-span-2">
-              <label className="block text-xs font-medium mb-1" htmlFor="invoices">
-                {t.invoices}
-              </label>
-              <input
-                id="invoices"
-                type="file"
-                multiple
-                accept="application/pdf,image/*"
-                onChange={handleInvoicesChange}
-                className="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-800 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-black focus:border-black dark:focus:ring-white dark:focus:border-white hover:border-gray-400 file:mr-2 file:py-1 file:px-2 file:rounded-md file:border-0 file:bg-black file:text-white hover:file:bg-gray-900 file:text-sm"
-              />
-              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                {invoices.length > 0
-                  ? invoices.map(f => f.name).join(', ')
-                  : t.invoicesHint}
-              </p>
-            </div>
-            <div className="sm:col-span-2">
-              <label className="block text-xs font-medium mb-1" htmlFor="mensaje">
-                {t.message}
-              </label>
-              <textarea
-                id="mensaje"
-                placeholder={t.messagePlaceholder}
-                value={mensaje}
-                onChange={e => setMensaje(e.target.value)}
-                className="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-800 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-black focus:border-black dark:focus:ring-white dark:focus:border-white hover:border-gray-400"
-                rows={4}
-              />
-            </div>
-            <div className="sm:col-span-2">
-              <button
-                type="submit"
-                className="w-full bg-black text-white rounded-full px-6 py-3 text-sm font-medium shadow hover:bg-gray-900 transition-transform hover:scale-[1.02] focus:outline-none focus:ring-4 focus:ring-gray-300 dark:focus:ring-gray-700"
-              >
-                {t.send}
-              </button>
-            </div>
+            <h1 className="text-2xl font-bold mt-4">
+              {locale === 'es' ? info.esName : info.enName}
+            </h1>
+            {info.rating && (
+              <p className="text-sm text-gray-600 dark:text-gray-400 mt-2">⭐ {info.rating}</p>
+            )}
+            <p className="text-sm text-gray-600 dark:text-gray-300 mt-2">
+              {locale === 'es' ? info.esDesc : info.enDesc}
+            </p>
           </div>
-        </form>
+          <form
+            onSubmit={handleSubmit}
+            className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-6 shadow-xl"
+          >
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-xs font-medium mb-1" htmlFor="nombre">
+                  {t.name}
+                </label>
+                <input
+                  id="nombre"
+                  type="text"
+                  placeholder={t.namePlaceholder}
+                  value={nombre}
+                  onChange={e => setNombre(e.target.value)}
+                  className="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-800 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-black focus:border-black dark:focus:ring-white dark:focus:border-white hover:border-gray-400"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium mb-1" htmlFor="email">
+                  {t.email}
+                </label>
+                <input
+                  id="email"
+                  type="email"
+                  placeholder={t.emailPlaceholder}
+                  value={email}
+                  onChange={e => setEmail(e.target.value)}
+                  className="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-800 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-black focus:border-black dark:focus:ring-white dark:focus:border-white hover:border-gray-400"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium mb-1" htmlFor="telefono">
+                  {t.phone}
+                </label>
+                <input
+                  id="telefono"
+                  type="tel"
+                  placeholder={t.phonePlaceholder}
+                  value={telefono}
+                  onChange={e => setTelefono(e.target.value)}
+                  className="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-800 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-black focus:border-black dark:focus:ring-white dark:focus:border-white hover:border-gray-400"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium mb-1" htmlFor="tipoPropiedad">
+                  {t.propertyType}
+                </label>
+                <select
+                  id="tipoPropiedad"
+                  value={tipoPropiedad}
+                  onChange={e => setTipoPropiedad(e.target.value)}
+                  className="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-800 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-black focus:border-black dark:focus:ring-white dark:focus:border-white hover:border-gray-400"
+                >
+                  <option value="">{t.propertyTypePlaceholder}</option>
+                  {t.propertyTypes.map(pt => (
+                    <option key={pt} value={pt}>
+                      {pt}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs font-medium mb-1" htmlFor="direccion">
+                  {t.address}
+                </label>
+                <input
+                  id="direccion"
+                  type="text"
+                  placeholder={t.addressPlaceholder}
+                  value={direccion}
+                  onChange={e => setDireccion(e.target.value)}
+                  className="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-800 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-black focus:border-black dark:focus:ring-white dark:focus:border-white hover:border-gray-400"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium mb-1" htmlFor="localidad">
+                  {t.city}
+                </label>
+                <input
+                  id="localidad"
+                  type="text"
+                  placeholder={t.cityPlaceholder}
+                  value={localidad}
+                  onChange={e => setLocalidad(e.target.value)}
+                  className="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-800 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-black focus:border-black dark:focus:ring-white dark:focus:border-white hover:border-gray-400"
+                />
+              </div>
+              {isSeguridad && (
+                <div className="sm:col-span-2">
+                  <span className="block text-xs font-medium mb-1">{t.sistemasTitle}</span>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                    {t.sistemasOptions.map(opt => (
+                      <label
+                        key={opt}
+                        className="flex items-center space-x-2 rounded-md p-2 hover:bg-gray-50 dark:hover:bg-gray-800 transition"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={sistemas.includes(opt)}
+                          onChange={() => toggleSistema(opt)}
+                          className="h-4 w-4 text-black dark:text-white focus:ring-black dark:focus:ring-white"
+                        />
+                        <span className="text-sm">{opt}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              )}
+              <div className="sm:col-span-2">
+                <label
+                  className="block text-sm font-semibold mb-2 text-gray-700 dark:text-gray-300"
+                  htmlFor="invoices"
+                >
+                  {t.invoices}
+                </label>
+                <input
+                  id="invoices"
+                  type="file"
+                  multiple
+                  accept="application/pdf,image/*"
+                  onChange={handleInvoicesChange}
+                  className="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-800 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-black focus:border-black dark:focus:ring-white dark:focus:border-white hover:border-gray-400 file:mr-2 file:py-1 file:px-2 file:rounded-md file:border-0 file:bg-black file:text-white hover:file:bg-gray-900 file:text-sm"
+                />
+                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  {invoices.length > 0
+                    ? invoices.map(f => f.name).join(', ')
+                    : t.invoicesHint}
+                </p>
+              </div>
+              <div className="sm:col-span-2">
+                <label className="block text-xs font-medium mb-1" htmlFor="mensaje">
+                  {t.message}
+                </label>
+                <textarea
+                  id="mensaje"
+                  placeholder={t.messagePlaceholder}
+                  value={mensaje}
+                  onChange={e => setMensaje(e.target.value)}
+                  className="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-800 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-black focus:border-black dark:focus:ring-white dark:focus:border-white hover:border-gray-400"
+                  rows={4}
+                />
+              </div>
+              <div className="sm:col-span-2">
+                <button
+                  type="submit"
+                  className="w-full bg-black text-white rounded-full px-6 py-3 text-sm font-medium shadow hover:bg-gray-900 transition-transform hover:scale-[1.02] focus:outline-none focus:ring-4 focus:ring-gray-300 dark:focus:ring-gray-700"
+                >
+                  {t.send}
+                </button>
+              </div>
+            </div>
+          </form>
+        </div>
       </main>
       <Footer t={footerT} />
+      {submitted && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white dark:bg-gray-800 p-6 rounded-lg text-center shadow-lg">
+            <span className="text-3xl mb-2 inline-block animate-bounce text-green-500">✓</span>
+            <h2 className="text-lg font-semibold mb-2">
+              {locale === 'es' ? 'Solicitud enviada' : 'Request Sent'}
+            </h2>
+            <p className="text-sm mb-4">
+              {locale === 'es'
+                ? 'Nos contactaremos contigo en menos de 24 horas.'
+                : 'We will get back to you within 24 hours.'}
+            </p>
+            <button
+              onClick={() => setSubmitted(false)}
+              className="bg-black text-white rounded-full px-4 py-2 text-sm hover:bg-gray-900"
+            >
+              {locale === 'es' ? 'Cerrar' : 'Close'}
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }
+
 


### PR DESCRIPTION
## Summary
- add localized "Request Service" buttons to service cards for quick quotes
- show service details with breadcrumb navigation and progress steps beside the request form
- preselect security options and display a confirmation modal after form submission

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689664a3bb9083269324219a1a86c9e0