### PR TITLE
feat: open services page from home search

### DIFF
--- a/src/app/services/[service]/ServiceFormClient.tsx
+++ b/src/app/services/[service]/ServiceFormClient.tsx
@@ -239,7 +239,6 @@ export default function ServiceFormClient({ service }: Props) {
 
   const isSeguridad = service.toLowerCase() === 'seguridad'
   const isLimpieza = service.toLowerCase() === 'limpieza'
-  const isFumigacion = service.toLowerCase() === 'fumigacion'
   const t = translations[locale]
   type ServiceInfo = typeof serviceInfo[keyof typeof serviceInfo]
   const info: ServiceInfo =

--- a/src/components/sections/home/HeroSection.tsx
+++ b/src/components/sections/home/HeroSection.tsx
@@ -148,7 +148,7 @@ export default function HeroSection({ t, userAddress, locale }: HeroProps) {
                     return (
                       <div
                         key={s.slug}
-                        onClick={() => handleSelect(s)}
+                        onPointerDown={() => handleSelect(s)}
                         className="px-4 py-2 hover:bg-gray-100 cursor-pointer text-sm"
                       >
                         {name}
@@ -196,7 +196,7 @@ export default function HeroSection({ t, userAddress, locale }: HeroProps) {
                     return (
                       <div
                         key={s.slug}
-                        onClick={() => handleSelect(s)}
+                        onPointerDown={() => handleSelect(s)}
                         className="px-4 py-2 hover:bg-gray-100 cursor-pointer text-sm"
                       >
                         {name}


### PR DESCRIPTION
## Summary
- ensure home page search suggestions open the selected service
- remove unused service flag

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689902170d3483269290b98375ac5283