### PR TITLE
Ensure service requests capture logged-in user

### DIFF
--- a/src/app/api/request-service/route.ts
+++ b/src/app/api/request-service/route.ts
@@ -17,6 +17,7 @@ export async function POST(request: Request) {
   const sistemas = JSON.parse(String(formData.get('sistemas') || '[]')) as string[]
   const lang = (formData.get('lang') === 'en' ? 'en' : 'es') as 'es' | 'en'
   const invoiceFiles = formData.getAll('invoices') as File[]
+  const userId = String(formData.get('userId') || '')
 
   if (invoiceFiles.length > 3) {
     return NextResponse.json({ error: 'Too many invoices' }, { status: 400 })
@@ -53,7 +54,8 @@ export async function POST(request: Request) {
     localidad,
     mensaje,
     sistemas,
-    invoice_urls: invoiceUrls
+    invoice_urls: invoiceUrls,
+    user_id: userId || null
   })
 
   const transporter = nodemailer.createTransport({

--- a/src/app/services/[service]/ServiceFormClient.tsx
+++ b/src/app/services/[service]/ServiceFormClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
+import useUser from '@/features/auth/useUser'
 import Image from 'next/image'
 import Navbar from '@/components/layout/Navbar'
 import Footer from '@/components/layout/Footer'
@@ -236,6 +237,7 @@ export default function ServiceFormClient({ service }: Props) {
   const [invoices, setInvoices] = useState<File[]>([])
   const [invoiceError, setInvoiceError] = useState('')
   const [submitted, setSubmitted] = useState(false)
+  const user = useUser()
 
   const isSeguridad = service.toLowerCase() === 'seguridad'
   const isLimpieza = service.toLowerCase() === 'limpieza'
@@ -259,6 +261,10 @@ export default function ServiceFormClient({ service }: Props) {
       setSistemas([])
     }
   }, [isSeguridad, locale])
+
+  useEffect(() => {
+    if (user?.email) setEmail(user.email)
+  }, [user])
 
   const toggleSistema = (value: string) => {
     setSistemas(prev =>
@@ -300,6 +306,9 @@ export default function ServiceFormClient({ service }: Props) {
     formData.append('mensaje', mensaje)
     formData.append('sistemas', JSON.stringify(sistemas))
     formData.append('lang', locale)
+    if (user?.id) {
+      formData.append('userId', user.id)
+    }
     invoices.forEach(f => formData.append('invoices', f))
     const res = await fetch('/api/request-service', {
       method: 'POST',


### PR DESCRIPTION
## Summary
- capture authenticated user in service request form and prefill their email
- include user id in request-service API payload to persist requester

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68990b39e4588326a63bed216c624782