### PR TITLE
Prefill service request form with user profile

### DIFF
--- a/src/app/services/[service]/ServiceFormClient.tsx
+++ b/src/app/services/[service]/ServiceFormClient.tsx
@@ -7,6 +7,7 @@ import Image from 'next/image'
 import Navbar from '@/components/layout/Navbar'
 import Footer from '@/components/layout/Footer'
 import Stepper from '@/components/ui/Stepper'
+import { supabase } from '@/lib/supabaseClient'
 
 const translations = {
   es: {
@@ -263,7 +264,24 @@ export default function ServiceFormClient({ service }: Props) {
   }, [isSeguridad, locale])
 
   useEffect(() => {
-    if (user?.email) setEmail(user.email)
+    if (!user) return
+
+    if (user.email) setEmail(user.email)
+
+    const loadProfile = async () => {
+      const { data } = await supabase
+        .from('api.profiles')
+        .select('full_name, phone, address, city')
+        .eq('id', user.id)
+        .single()
+
+      if (data?.full_name) setNombre(data.full_name)
+      if (data?.phone) setTelefono(data.phone)
+      if (data?.address) setDireccion(data.address)
+      if (data?.city) setLocalidad(data.city)
+    }
+
+    loadProfile()
   }, [user])
 
   const toggleSistema = (value: string) => {


### PR DESCRIPTION
## Summary
- Prefill service request form fields with user's name, phone, address and city from Supabase profile

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68990d123cc08326b64687e394597f2b