### PR TITLE
Handle missing Supabase credentials in service request API

### DIFF
--- a/src/app/api/request-service/route.ts
+++ b/src/app/api/request-service/route.ts
@@ -1,9 +1,18 @@
 import { NextResponse } from 'next/server'
-import { supabaseAdmin } from '@/lib/supabaseAdmin'
+import { getSupabaseAdmin } from '@/lib/supabaseAdmin'
+import type { SupabaseClient } from '@supabase/supabase-js'
 import nodemailer, { type Attachment } from 'nodemailer'
 import { randomUUID } from 'crypto'
 
 export async function POST(request: Request) {
+  let supabaseAdmin: SupabaseClient
+  try {
+    supabaseAdmin = getSupabaseAdmin()
+  } catch (err) {
+    console.error(err)
+    return NextResponse.json({ error: 'Server misconfigured' }, { status: 500 })
+  }
+
   const formData = await request.formData()
   const service = String(formData.get('service') || '')
   const nombre = String(formData.get('nombre') || '')

--- a/src/lib/supabaseAdmin.ts
+++ b/src/lib/supabaseAdmin.ts
@@ -1,8 +1,17 @@
-import { createClient } from '@supabase/supabase-js'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
+let client: SupabaseClient | null = null
 
-export const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey, {
-  db: { schema: 'api' }
-})
+export function getSupabaseAdmin(): SupabaseClient {
+  if (client) return client
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!url || !serviceKey) {
+    throw new Error('Missing Supabase credentials')
+  }
+
+  client = createClient(url, serviceKey, { db: { schema: 'api' } })
+  return client
+}


### PR DESCRIPTION
## Summary
- lazily initialize Supabase admin client
- catch missing credential errors in request-service API

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689913c8a27c83269ad177dcedaaf13c