### PR TITLE
Handle missing Supabase credentials in service request API

### DIFF
--- a/src/app/api/request-service/route.ts
+++ b/src/app/api/request-service/route.ts
@@ -1,9 +1,18 @@
 import { NextResponse } from 'next/server'
-import { supabaseAdmin } from '@/lib/supabaseAdmin'
+import { getSupabaseAdmin } from '@/lib/supabaseAdmin'
+import type { SupabaseClient } from '@supabase/supabase-js'
 import nodemailer, { type Attachment } from 'nodemailer'
 import { randomUUID } from 'crypto'
 
 export async function POST(request: Request) {
+  let supabaseAdmin: SupabaseClient
+  try {
+    supabaseAdmin = getSupabaseAdmin()
+  } catch (err) {
+    console.error(err)
+    return NextResponse.json({ error: 'Server misconfigured' }, { status: 500 })
+  }
+
   const formData = await request.formData()
   const service = String(formData.get('service') || '')
   const nombre = String(formData.get('nombre') || '')
@@ -58,15 +67,22 @@ export async function POST(request: Request) {
     user_id: userId || null
   })
 
-  const transporter = nodemailer.createTransport({
-    host: process.env.SMTP_HOST,
-    port: Number(process.env.SMTP_PORT || 587),
-    secure: false,
-    auth: {
-      user: process.env.SMTP_USER,
-      pass: process.env.SMTP_PASS
+  let transporter
+  try {
+    const { SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS } = process.env
+    if (!SMTP_HOST || !SMTP_PORT || !SMTP_USER || !SMTP_PASS) {
+      throw new Error('Missing SMTP credentials')
     }
-  })
+    transporter = nodemailer.createTransport({
+      host: SMTP_HOST,
+      port: Number(SMTP_PORT || 587),
+      secure: false,
+      auth: { user: SMTP_USER, pass: SMTP_PASS }
+    })
+  } catch (err) {
+    console.error(err)
+    return NextResponse.json({ error: 'Server misconfigured' }, { status: 500 })
+  }
 
   attachments.push({
     filename: 'logo.png',
@@ -85,8 +101,8 @@ export async function POST(request: Request) {
       : `<div style="font-family:sans-serif"><img src="cid:presu-logo" alt="PRESU" style="height:60px"/><h2>Nueva Solicitud de Servicio</h2><p>Has recibido una nueva solicitud para <strong>${service}</strong>.</p><p><strong>Nombre:</strong> ${nombre}<br/><strong>Email:</strong> ${email}<br/><strong>Teléfono:</strong> ${telefono}</p><p>${mensaje}</p></div>`
 
   await transporter.sendMail({
-    from: process.env.SMTP_FROM,
-    to: 'rlabarile@analytxcg.com',
+    from: email,
+    to: 'rlabarile@analytixcg.com',
     subject,
     html,
     attachments

--- a/src/lib/supabaseAdmin.ts
+++ b/src/lib/supabaseAdmin.ts
@@ -1,8 +1,17 @@
-import { createClient } from '@supabase/supabase-js'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
+let client: SupabaseClient | null = null
 
-export const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey, {
-  db: { schema: 'api' }
-})
+export function getSupabaseAdmin(): SupabaseClient {
+  if (client) return client
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!url || !serviceKey) {
+    throw new Error('Missing Supabase credentials')
+  }
+
+  client = createClient(url, serviceKey, { db: { schema: 'api' } })
+  return client
+}


### PR DESCRIPTION
## Summary
- lazily initialize Supabase admin client
- catch missing credential errors in request-service API
- validate SMTP config and send request emails from user address

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689913c8a27c83269ad177dcedaaf13c