### PR TITLE
fix: set request-service route to node runtime

### DIFF
--- a/src/app/api/request-service/route.ts
+++ b/src/app/api/request-service/route.ts
@@ -3,6 +3,8 @@ import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 import nodemailer, { type Attachment } from 'nodemailer'
 import { randomUUID } from 'crypto'
 
+export const runtime = 'nodejs'
+
 export async function POST(request: Request) {
   const {
     NEXT_PUBLIC_SUPABASE_URL,


### PR DESCRIPTION
## Summary
- ensure `/api/request-service` runs on the Node runtime

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68991f230d488326aeb7b5b7c81660ae