### PR TITLE
fix: remove duplicate runtime export

### DIFF
--- a/src/app/api/request-service/route.ts
+++ b/src/app/api/request-service/route.ts
@@ -1,9 +1,9 @@
-export const runtime = 'nodejs'
-
 import { NextResponse } from 'next/server'
 import nodemailer, { type Attachment } from 'nodemailer'
 import { randomUUID } from 'crypto'
 import { getSupabaseAdmin } from '@/lib/supabaseAdmin'
+
+export const runtime = 'nodejs'
 
 async function parseBody(req: Request) {
   const ct = req.headers.get('content-type') || ''
@@ -30,8 +30,6 @@ async function parseBody(req: Request) {
   const files = fd.getAll('invoices') as File[]
   return { data, files }
 }
-
-export const runtime = 'nodejs'
 
 export async function POST(request: Request) {
   let supabaseAdmin


### PR DESCRIPTION
## Summary
- remove duplicate `runtime` declaration from request-service route

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `curl -s -w '\n%{http_code}\n' -X POST http://localhost:3000/api/request-service -H 'Content-Type: application/json' -d '{"service":"Test","nombre":"John","email":"john@example.com","telefono":"123","tipoPropiedad":"house","cleaningType":"standard","direccion":"1 St","localidad":"City","mensaje":"Hello","sistemas":[],"lang":"en","userId":""}'` *(500, DB insert failed)*

------
https://chatgpt.com/codex/tasks/task_e_689921bfa3248326a9001d95f462b9c0