### PR TITLE
fix: grant service role access

### DIFF
--- a/src/app/api/request-service/route.ts
+++ b/src/app/api/request-service/route.ts
@@ -20,7 +20,7 @@ type JsonBody = {
   direccion?: string
   localidad?: string
   mensaje?: string
-  sistemas?: any[]
+  sistemas?: unknown[]
   lang?: 'es' | 'en'
   userId?: string
   deadline?: string // yyyy-mm-dd (optional)
@@ -148,13 +148,14 @@ export async function POST(request: Request) {
     .select('id')
     .single()
 
-  if (dbErr) {
-    if (!isProd) console.error('Insert failed:', dbErr)
-    return NextResponse.json(
-      { error: 'DB insert failed', code: dbErr.code, message: dbErr.message, details: (dbErr as any).details, hint: (dbErr as any).hint },
-      { status: 500 }
-    )
-  }
+    if (dbErr) {
+      if (!isProd) console.error('Insert failed:', dbErr)
+      const err = dbErr as { details?: string | null; hint?: string | null }
+      return NextResponse.json(
+        { error: 'DB insert failed', code: dbErr.code, message: dbErr.message, details: err.details, hint: err.hint },
+        { status: 500 }
+      )
+    }
 
   // 6) Email notification
   const { SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, SMTP_FROM } = process.env

--- a/src/lib/supabaseAdmin.ts
+++ b/src/lib/supabaseAdmin.ts
@@ -1,13 +1,13 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
-let client: SupabaseClient<any, 'api'> | null = null
+let client: SupabaseClient<unknown, 'api'> | null = null
 
-export function getSupabaseAdmin(): SupabaseClient<any, 'api'> {
+export function getSupabaseAdmin(): SupabaseClient<unknown, 'api'> {
   if (client) return client
 
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL!
   const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
-  client = createClient<any, 'api'>(url, serviceKey, {
+  client = createClient<unknown, 'api'>(url, serviceKey, {
     auth: { persistSession: false },
     db: { schema: 'api' },
   })

--- a/supabase/api-schema.sql
+++ b/supabase/api-schema.sql
@@ -85,3 +85,11 @@ create table if not exists api.service_request_services (
   provider_id uuid references api.providers(id) on delete set null,
   primary key (request_id, service_slug)
 );
+
+-- Grant API schema privileges to service_role
+grant usage on schema api to service_role;
+grant all on api.profiles to service_role;
+grant all on api.providers to service_role;
+grant all on api.provider_services to service_role;
+grant all on api.service_requests to service_role;
+grant all on api.service_request_services to service_role;

--- a/supabase/services.sql
+++ b/supabase/services.sql
@@ -34,5 +34,5 @@ create or replace view api.services as
   from reference.services;
 
 -- Allow read access to the view for anonymous and authenticated users
-grant usage on schema api to anon, authenticated;
-grant select on api.services to anon, authenticated;
+grant usage on schema api to anon, authenticated, service_role;
+grant select on api.services to anon, authenticated, service_role;


### PR DESCRIPTION
## Summary
- grant service_role explicit privileges on api schema tables
- allow service_role to read api.services view
- clean up `any` types in admin client and request-service API

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68992c65f830832691e3c4a514064c24