### PR TITLE
Redirect to services page after service request

### DIFF
--- a/src/app/services/[service]/ServiceFormClient.tsx
+++ b/src/app/services/[service]/ServiceFormClient.tsx
@@ -242,7 +242,6 @@ export default function ServiceFormClient({ service }: Props) {
   const [sistemas, setSistemas] = useState<string[]>([])
   const [invoices, setInvoices] = useState<File[]>([])
   const [invoiceError, setInvoiceError] = useState('')
-  const [submitted, setSubmitted] = useState(false)
   const [error, setError] = useState('')
   const user = useUser()
 
@@ -348,7 +347,6 @@ export default function ServiceFormClient({ service }: Props) {
         body: formData
       })
       if (!res.ok) throw new Error('Request failed')
-      setSubmitted(true)
       setNombre('')
       setEmail('')
       setTelefono('')
@@ -360,6 +358,7 @@ export default function ServiceFormClient({ service }: Props) {
       setMensaje('')
       setSistemas([])
       setInvoices([])
+      router.push(`/services?lang=${locale}`)
     } catch {
       setError(
         locale === 'es'
@@ -641,27 +640,6 @@ export default function ServiceFormClient({ service }: Props) {
         </div>
       </main>
       <Footer t={footerT} />
-        {submitted && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div className="bg-white dark:bg-gray-800 p-6 rounded-lg text-center shadow-lg">
-            <span className="text-3xl mb-2 inline-block animate-bounce text-green-500">✓</span>
-            <h2 className="text-lg font-semibold mb-2">
-              {locale === 'es' ? 'Solicitud enviada' : 'Request Sent'}
-            </h2>
-            <p className="text-sm mb-4">
-              {locale === 'es'
-                ? 'Nos contactaremos contigo en menos de 24 horas.'
-                : 'We will get back to you within 24 hours.'}
-            </p>
-            <button
-              onClick={() => setSubmitted(false)}
-              className="bg-black text-white rounded-full px-4 py-2 text-sm hover:bg-gray-900"
-            >
-              {locale === 'es' ? 'Cerrar' : 'Close'}
-            </button>
-          </div>
-        </div>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Redirect users back to services listing after a service request is sent
- Remove unused success modal state

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689942b758288326a0b1d4cd13236560