### PR TITLE
feat: add provider link to navbar

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -28,6 +28,9 @@ export default function Navbar({ locale, toggleLocale, t, forceWhite = false }: 
   const [drawerOpen, setDrawerOpen] = useState(false)
   const user = useUser()
 
+  const providerLabel =
+    locale === 'es' ? 'Quiero ser proveedor' : 'Join as a provider'
+
   useEffect(() => {
     setMounted(true)
     const handleScroll = () => setScrolled(window.scrollY > 20)
@@ -120,6 +123,13 @@ export default function Navbar({ locale, toggleLocale, t, forceWhite = false }: 
                   className="bg-black text-white px-5 py-2 rounded-full font-medium hover:bg-gray-800 transition"
                 >
                   {t.signup}
+                </button>
+
+                <button
+                  onClick={() => router.push(`/auth/register?role=pro&lang=${locale}`)}
+                  className="bg-gradient-to-r from-purple-600 to-indigo-600 text-white px-5 py-2 rounded-full font-medium hover:from-purple-700 hover:to-indigo-700 transition"
+                >
+                  {providerLabel}
                 </button>
               </>
             )}

--- a/src/components/layout/SideMenu.tsx
+++ b/src/components/layout/SideMenu.tsx
@@ -84,14 +84,14 @@ export default function SideMenu({
           </button>
 
           {/* Additional Options */}
-          <ul className="text-sm space-y-4 font-semibold mt-6">
+          <ul className="space-y-4 font-semibold mt-6">
             <li>
               <button
                 onClick={() => {
                   router.push(`/auth/register?role=pro&lang=${locale}`)
                   onClose()
                 }}
-                className="w-full text-left pl-4"
+                className="w-full text-center text-base py-2"
               >
                 {providerLabel}
               </button>


### PR DESCRIPTION
## Summary
- enlarge and center side menu "Join as a provider" link
- add a gradient "Join as a provider" button to desktop navbar

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899449aae448326b3d09c5692466514