### PR TITLE
Polish auth UI and service email

### DIFF
--- a/src/app/api/request-service/route.ts
+++ b/src/app/api/request-service/route.ts
@@ -192,8 +192,58 @@ export async function POST(request: Request) {
 
   const subject = lang === 'en' ? 'New service request' : 'Nueva solicitud de servicio'
   const html = lang === 'en'
-    ? `<div style="font-family:sans-serif"><img src="cid:presu-logo" alt="PRESU" style="height:60px"/><h2>New Service Request</h2><p>${description || ''}</p><p><strong>Name:</strong> ${nombre || ''}<br/><strong>Email:</strong> ${email || ''}<br/><strong>Phone:</strong> ${telefono || ''}</p></div>`
-    : `<div style="font-family:sans-serif"><img src="cid:presu-logo" alt="PRESU" style="height:60px"/><h2>Nueva Solicitud de Servicio</h2><p>${description || ''}</p><p><strong>Nombre:</strong> ${nombre || ''}<br/><strong>Email:</strong> ${email || ''}<br/><strong>Teléfono:</strong> ${telefono || ''}</p></div>`
+    ? `
+      <div style="background-color:#f9f9f9;padding:20px;font-family:Arial,sans-serif;color:#333;">
+        <table width="100%" cellpadding="0" cellspacing="0" style="max-width:600px;margin:auto;background:#ffffff;border-radius:8px;overflow:hidden;">
+          <tr>
+            <td style="text-align:center;padding:20px 20px 0;">
+              <img src="cid:presu-logo" alt="PRESU" style="height:60px"/>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:20px;text-align:center;">
+              <h2 style="margin:0;font-size:20px;">New Service Request</h2>
+              <p style="margin:10px 0 0;">${description || ''}</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:0 20px 20px;">
+              <table width="100%" cellpadding="0" cellspacing="0">
+                <tr><td style="font-weight:bold;padding:4px 0;">Name:</td><td>${nombre || ''}</td></tr>
+                <tr><td style="font-weight:bold;padding:4px 0;">Email:</td><td>${email || ''}</td></tr>
+                <tr><td style="font-weight:bold;padding:4px 0;">Phone:</td><td>${telefono || ''}</td></tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </div>
+    `
+    : `
+      <div style="background-color:#f9f9f9;padding:20px;font-family:Arial,sans-serif;color:#333;">
+        <table width="100%" cellpadding="0" cellspacing="0" style="max-width:600px;margin:auto;background:#ffffff;border-radius:8px;overflow:hidden;">
+          <tr>
+            <td style="text-align:center;padding:20px 20px 0;">
+              <img src="cid:presu-logo" alt="PRESU" style="height:60px"/>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:20px;text-align:center;">
+              <h2 style="margin:0;font-size:20px;">Nueva Solicitud de Servicio</h2>
+              <p style="margin:10px 0 0;">${description || ''}</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:0 20px 20px;">
+              <table width="100%" cellpadding="0" cellspacing="0">
+                <tr><td style="font-weight:bold;padding:4px 0;">Nombre:</td><td>${nombre || ''}</td></tr>
+                <tr><td style="font-weight:bold;padding:4px 0;">Email:</td><td>${email || ''}</td></tr>
+                <tr><td style="font-weight:bold;padding:4px 0;">Teléfono:</td><td>${telefono || ''}</td></tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </div>
+    `
 
   try {
     await transporter.sendMail({

--- a/src/app/auth/forgot-password/components/ForgotPasswordForm.tsx
+++ b/src/app/auth/forgot-password/components/ForgotPasswordForm.tsx
@@ -58,8 +58,8 @@ export default function ForgotPasswordComponent({
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-gray-100 dark:from-gray-900 dark:to-gray-800 px-4">
-      <div className="w-full max-w-md bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-8">
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-gray-100 dark:from-gray-900 dark:to-gray-800 px-4 text-gray-900 dark:text-white">
+      <div className="w-full max-w-md bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-8 border border-gray-200 dark:border-gray-700">
         <h2 className="text-2xl font-extrabold text-center text-gray-900 dark:text-white mb-6">
           {t?.title}
         </h2>

--- a/src/app/auth/login/components/LoginClient.tsx
+++ b/src/app/auth/login/components/LoginClient.tsx
@@ -29,7 +29,9 @@ export default function LoginPageClient() {
       password: 'Password',
       forgotPassword: 'Forgot your password?',
       loggingIn: 'Logging in...',
-      login: 'Log in'
+      login: 'Log in',
+      noAccount: "Don't have an account?",
+      register: 'Sign up'
     },
     es: {
       loginTo: 'Bienvenido nuevamente',
@@ -40,7 +42,9 @@ export default function LoginPageClient() {
       password: 'Contraseña',
       forgotPassword: '¿Olvidaste tu contraseña?',
       loggingIn: 'Iniciando sesión...',
-      login: 'Iniciar sesión'
+      login: 'Iniciar sesión',
+      noAccount: '¿No tienes una cuenta?',
+      register: 'Regístrate'
     }
   }[locale]
 

--- a/src/app/auth/login/components/LoginForm.tsx
+++ b/src/app/auth/login/components/LoginForm.tsx
@@ -18,6 +18,8 @@ type LoginComponentProps = {
     forgotPassword: string
     loggingIn: string
     login: string
+    noAccount: string
+    register: string
   }
 }
 
@@ -30,7 +32,9 @@ const defaultT: LoginComponentProps['t'] = {
   password: 'Password',
   forgotPassword: 'Forgot your password?',
   loggingIn: 'Logging in...',
-  login: 'Login'
+  login: 'Login',
+  noAccount: "Don't have an account?",
+  register: 'Sign up'
 }
 
 export default function LoginComponent({ locale = 'en', t = defaultT }: LoginComponentProps) {
@@ -77,24 +81,33 @@ export default function LoginComponent({ locale = 'en', t = defaultT }: LoginCom
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-900 text-white relative px-4">
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-gray-100 dark:from-gray-900 dark:to-gray-800 text-gray-900 dark:text-white relative px-4">
       {/* Close button */}
       <button
-        className="absolute top-4 right-4 text-white hover:text-gray-300"
+        className="absolute top-4 right-4 text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white"
         onClick={() => router.push('/')}
         aria-label="Close"
       >
         <X size={20} weight="bold" />
       </button>
 
-      <div className="w-full max-w-sm bg-gray-800 rounded-2xl shadow-xl p-8 space-y-6 border border-gray-700 text-center">
-        <h2 className="text-3xl font-handwritten font-medium tracking-widest mb-6">
+      <div className="w-full max-w-md bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-8 space-y-6 border border-gray-200 dark:border-gray-700">
+        <h2 className="text-2xl font-extrabold text-center mb-2">
           {t.loginTo}
         </h2>
+        <p className="text-sm text-center text-gray-600 dark:text-gray-400">
+          {t.noAccount}{' '}
+          <a
+            href={`/auth/register?lang=${lang}`}
+            className="text-red-600 font-semibold hover:underline"
+          >
+            {t.register}
+          </a>
+        </p>
 
         <button
           onClick={handleGoogleLogin}
-          className="w-full flex items-center justify-center gap-2 bg-white text-black border border-gray-300 px-4 py-2 rounded-md hover:bg-gray-100 transition disabled:opacity-50 text-sm"
+          className="w-full flex items-center justify-center gap-2 bg-white text-black border border-gray-300 px-4 py-2 rounded-lg hover:bg-gray-50 transition disabled:opacity-50 text-sm font-medium"
           disabled={googleLoading}
         >
           {googleLoading && <span className="loader border-blue-500" />}
@@ -103,29 +116,35 @@ export default function LoginComponent({ locale = 'en', t = defaultT }: LoginCom
         </button>
 
         <div className="relative text-center">
-          <span className="text-xs text-gray-400 px-2 bg-gray-800 z-10 relative">
+          <span className="text-xs text-gray-400 px-2 bg-white dark:bg-gray-800 z-10 relative">
             {t.orLoginWithEmail}
           </span>
-          <div className="absolute top-1/2 left-0 w-full border-t border-gray-600 -z-0 transform -translate-y-1/2" />
+          <div className="absolute top-1/2 left-0 w-full border-t border-gray-300 dark:border-gray-600 -z-0 transform -translate-y-1/2" />
         </div>
 
-        <div>
+        <div className="text-left">
+          <label className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">
+            {t.email}
+          </label>
           <input
             type="email"
             placeholder={t.email}
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-700 rounded-md bg-gray-900 text-white focus:outline-none focus:ring-2 focus:ring-red-500 text-sm"
+            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-700 rounded-lg bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-red-500 text-sm"
           />
         </div>
 
-        <div>
+        <div className="text-left">
+          <label className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">
+            {t.password}
+          </label>
           <input
             type="password"
             placeholder={t.password}
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-700 rounded-md bg-gray-900 text-white focus:outline-none focus:ring-2 focus:ring-red-500 text-sm"
+            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-700 rounded-lg bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-red-500 text-sm"
           />
         </div>
 
@@ -143,7 +162,7 @@ export default function LoginComponent({ locale = 'en', t = defaultT }: LoginCom
         <button
           onClick={handleLogin}
           disabled={loading}
-          className="w-full bg-red-500 hover:bg-red-600 text-white py-2 rounded-md font-semibold text-sm transition disabled:opacity-50"
+          className="w-full bg-red-500 hover:bg-red-600 text-white py-2 rounded-lg font-semibold text-sm transition disabled:opacity-50 shadow"
         >
           {loading ? t.loggingIn : t.login}
         </button>

--- a/src/app/auth/register/components/RegisterForm.tsx
+++ b/src/app/auth/register/components/RegisterForm.tsx
@@ -90,25 +90,25 @@ export default function RegisterComponent({ t = defaultT }: RegisterProps) {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-900 text-white relative px-4">
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-gray-100 dark:from-gray-900 dark:to-gray-800 text-gray-900 dark:text-white relative px-4">
       {/* Close button */}
       <button
-        className="absolute top-4 right-4 text-white hover:text-gray-300"
+        className="absolute top-4 right-4 text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white"
         onClick={() => router.push('/')}
         aria-label="Close"
       >
         <X size={20} weight="bold" />
       </button>
 
-      <div className="w-full max-w-sm bg-gray-800 rounded-2xl shadow-xl p-8 space-y-6 border border-gray-700 text-center">
-        <h2 className="text-3xl font-handwritten font-medium tracking-widest mb-6">
+      <div className="w-full max-w-md bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-8 space-y-6 border border-gray-200 dark:border-gray-700">
+        <h2 className="text-2xl font-extrabold text-center mb-2">
           {t.createAccount}
         </h2>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-center text-gray-600 dark:text-gray-400">
           {t.alreadyHaveAccount}{' '}
           <a
             href={`/auth/login${lang ? `?lang=${lang}` : ''}`}
-            className="text-red-500 font-semibold hover:underline"
+            className="text-red-600 font-semibold hover:underline"
           >
             {t.login}
           </a>
@@ -117,7 +117,7 @@ export default function RegisterComponent({ t = defaultT }: RegisterProps) {
         {/* Google Signup */}
         <button
           onClick={handleGoogleSignup}
-          className="w-full flex items-center justify-center gap-2 bg-white text-black border border-gray-300 px-4 py-2 rounded-md hover:bg-gray-100 transition disabled:opacity-50 text-sm"
+          className="w-full flex items-center justify-center gap-2 bg-white text-black border border-gray-300 px-4 py-2 rounded-lg hover:bg-gray-50 transition disabled:opacity-50 text-sm font-medium"
           disabled={googleLoading}
         >
           {googleLoading && <span className="loader border-blue-500" />}
@@ -127,31 +127,37 @@ export default function RegisterComponent({ t = defaultT }: RegisterProps) {
 
         {/* Divider */}
         <div className="relative text-center">
-          <span className="text-xs text-gray-400 px-2 bg-gray-800 z-10 relative">
+          <span className="text-xs text-gray-400 px-2 bg-white dark:bg-gray-800 z-10 relative">
             {t.orSignupWithEmail}
           </span>
-          <div className="absolute top-1/2 left-0 w-full border-t border-gray-600 -z-0 transform -translate-y-1/2" />
+          <div className="absolute top-1/2 left-0 w-full border-t border-gray-300 dark:border-gray-600 -z-0 transform -translate-y-1/2" />
         </div>
 
         {/* Email input */}
-        <div>
+        <div className="text-left">
+          <label className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">
+            {t.email}
+          </label>
           <input
             type="email"
             placeholder={t.email}
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-700 rounded-md bg-gray-900 text-white focus:outline-none focus:ring-2 focus:ring-red-500 text-sm"
+            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-700 rounded-lg bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-red-500 text-sm"
           />
         </div>
 
         {/* Password input */}
-        <div>
+        <div className="text-left">
+          <label className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">
+            {t.password}
+          </label>
           <input
             type="password"
             placeholder={t.password}
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-700 rounded-md bg-gray-900 text-white focus:outline-none focus:ring-2 focus:ring-red-500 text-sm"
+            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-700 rounded-lg bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-red-500 text-sm"
           />
         </div>
 
@@ -162,7 +168,7 @@ export default function RegisterComponent({ t = defaultT }: RegisterProps) {
         <button
           onClick={handleRegister}
           disabled={loading}
-          className="w-full bg-red-500 hover:bg-red-600 text-white py-2 rounded-md font-semibold text-sm transition disabled:opacity-50"
+          className="w-full bg-red-500 hover:bg-red-600 text-white py-2 rounded-lg font-semibold text-sm transition disabled:opacity-50 shadow"
         >
           {loading ? t.registering : t.register}
         </button>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -38,6 +38,13 @@ export default function Navbar({ locale, toggleLocale, t, forceWhite = false }: 
     return () => window.removeEventListener('scroll', handleScroll)
   }, [])
 
+  useEffect(() => {
+    if (!user) {
+      router.prefetch(`/auth/login?lang=${locale}`)
+      router.prefetch(`/auth/register?lang=${locale}`)
+    }
+  }, [router, locale, user])
+
   if (!mounted) return null
 
   const isLightBg = forceWhite || scrolled


### PR DESCRIPTION
## Summary
- restyle login, register, and password reset screens with a unified card design
- prefetch auth pages for quicker initial load
- format service request notification email with a cleaner layout

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build` (fails: Failed to fetch `Geist` fonts)

------
https://chatgpt.com/codex/tasks/task_e_689946f03b988326af6501636aab865f