### PR TITLE
Use hosted logo for production email attachments

### DIFF
--- a/src/app/api/request-service/route.ts
+++ b/src/app/api/request-service/route.ts
@@ -186,7 +186,9 @@ export async function POST(request: Request) {
 
   mailAttachments.push({
     filename: 'logo.png',
-    path: `${process.cwd()}/public/logo/presu-02.png`,
+    path: isProd
+      ? 'https://payeutapaokdwxqxesyz.supabase.co/storage/v1/object/public/app/presu-02.png'
+      : `${process.cwd()}/public/logo/presu-02.png`,
     cid: 'presu-logo',
   })
 


### PR DESCRIPTION
## Summary
- Load email logo from Supabase storage in production, falling back to local file in development

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68994e72ebd48326820a474b1445bf12