### PR TITLE
Add user settings page and Supabase storage initialization

### DIFF
--- a/src/app/api/create-user-folder/route.ts
+++ b/src/app/api/create-user-folder/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server'
+import { getSupabaseAdmin } from '@/lib/supabaseAdmin'
+
+export const runtime = 'nodejs'
+
+export async function POST(req: Request) {
+  try {
+    const { userId } = await req.json()
+    if (!userId) {
+      return NextResponse.json({ error: 'Missing userId' }, { status: 400 })
+    }
+
+    const supabase = getSupabaseAdmin()
+    const bucket = 'user-uploads'
+
+    // Ensure bucket exists
+    const { data: bucketInfo } = await supabase.storage.getBucket(bucket)
+    if (!bucketInfo) {
+      await supabase.storage.createBucket(bucket, { public: true })
+    }
+
+    const filePath = `${userId}/.keep`
+    const { error: uploadError } = await supabase.storage
+      .from(bucket)
+      .upload(filePath, Buffer.from('init'), { upsert: false, contentType: 'text/plain' })
+
+    if (uploadError && !uploadError.message.includes('exists')) {
+      return NextResponse.json({ error: uploadError.message }, { status: 500 })
+    }
+
+    return NextResponse.json({ ok: true })
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e)
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -10,6 +10,11 @@ export default function CallbackPage() {
     const recover = async () => {
       const { data, error } = await supabase.auth.getSession()
       if (data.session) {
+        await fetch('/api/create-user-folder', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ userId: data.session.user.id })
+        })
         router.push('/') // 🔄 Now goes to homepage
       } else {
         console.error('Recovery failed:', error?.message)

--- a/src/app/auth/register/components/RegisterForm.tsx
+++ b/src/app/auth/register/components/RegisterForm.tsx
@@ -55,12 +55,20 @@ export default function RegisterComponent({ t = defaultT }: RegisterProps) {
       email,
       password,
       options: {
-        data: { 
+        data: {
           full_name: email.split('@')[0],
           locale: lang
         }
       }
     })
+
+    if (!error && data?.user) {
+      await fetch('/api/create-user-folder', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId: data.user.id })
+      })
+    }
 
     if (error) {
       setError(error.message)

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Image from 'next/image'
+import { supabase } from '@/lib/supabaseClient'
+import useUser from '@/features/auth/useUser'
+
+export default function SettingsPage() {
+  const user = useUser()
+  const [fullName, setFullName] = useState('')
+  const [avatarUrl, setAvatarUrl] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [uploading, setUploading] = useState(false)
+
+  useEffect(() => {
+    const loadProfile = async () => {
+      if (!user) return
+      setAvatarUrl(user.user_metadata?.avatar_url || '')
+      const { data } = await supabase
+        .from('api.profiles')
+        .select('full_name')
+        .eq('id', user.id)
+        .single()
+      if (data?.full_name) setFullName(data.full_name)
+    }
+    loadProfile()
+  }, [user])
+
+  const handleSave = async () => {
+    if (!user) return
+    setSaving(true)
+    await supabase.auth.updateUser({ data: { full_name: fullName, avatar_url: avatarUrl } })
+    await supabase.from('api.profiles').upsert({ id: user.id, full_name: fullName })
+    setSaving(false)
+  }
+
+  const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!user) return
+    const file = e.target.files?.[0]
+    if (!file) return
+    setUploading(true)
+    const ext = file.name.split('.').pop()
+    const filePath = `${user.id}/avatar.${ext}`
+    const { error } = await supabase.storage.from('user-uploads').upload(filePath, file, { upsert: true })
+    if (!error) {
+      const { data } = supabase.storage.from('user-uploads').getPublicUrl(filePath)
+      setAvatarUrl(data.publicUrl)
+      await supabase.auth.updateUser({ data: { avatar_url: data.publicUrl } })
+    }
+    setUploading(false)
+  }
+
+  if (!user) return <div className="p-6">Loading...</div>
+
+  return (
+    <div className="max-w-xl mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-6">Settings</h1>
+      <div className="flex flex-col gap-6">
+        <div className="flex items-center gap-4">
+          <Image
+            src={avatarUrl || '/images/user/user-placeholder.png'}
+            alt="Avatar"
+            width={80}
+            height={80}
+            className="rounded-full"
+          />
+          <div>
+            <label className="block text-sm font-medium mb-1">Photo</label>
+            <input type="file" accept="image/*" onChange={handleUpload} disabled={uploading} />
+          </div>
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Full name</label>
+          <input
+            type="text"
+            value={fullName}
+            onChange={(e) => setFullName(e.target.value)}
+            className="w-full border rounded px-3 py-2"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Email</label>
+          <input
+            type="text"
+            value={user.email}
+            disabled
+            className="w-full border rounded px-3 py-2 bg-gray-100"
+          />
+        </div>
+        <button
+          onClick={handleSave}
+          disabled={saving}
+          className="self-start bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded"
+        >
+          {saving ? 'Saving...' : 'Save'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/layout/UserMenu.tsx
+++ b/src/components/layout/UserMenu.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect } from 'react'
 import Image from 'next/image'
+import Link from 'next/link'
 import { supabase } from '@/lib/supabaseClient'
 import { useRouter } from 'next/navigation'
 import { User } from '@supabase/supabase-js'
@@ -138,10 +139,14 @@ export default function UserMenu({ user, locale }: Props) {
 
                 {/* Settings - Centered */}
                 <div className="px-5 pt-3">
-                    <div className="flex flex-col items-center justify-center hover:bg-gray-100 rounded-xl transition transform hover:scale-105 py-4 cursor-pointer">
+                    <Link
+                        href="/settings"
+                        onClick={() => setOpen(false)}
+                        className="flex flex-col items-center justify-center hover:bg-gray-100 rounded-xl transition transform hover:scale-105 py-4"
+                    >
                         <Image src="/images/user/user-settings.png" alt={settingsAlt} width={28} height={28} />
                         <span className="text-sm font-semibold mt-1">{settingsText}</span>
-                    </div>
+                    </Link>
                 </div>
 
                 {/* Logout */}


### PR DESCRIPTION
## Summary
- link settings page from user menu
- create API route to initialize per-user storage folder in Supabase
- add UI for editing profile and uploading avatar

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899dbb7e2108326a36f50d8a4d0b0b9