### PR TITLE
Add user settings page and Supabase storage initialization

### DIFF
--- a/src/app/api/create-user-folder/route.ts
+++ b/src/app/api/create-user-folder/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server'
+import { getSupabaseAdmin } from '@/lib/supabaseAdmin'
+
+export const runtime = 'nodejs'
+
+export async function POST(req: Request) {
+  try {
+    const { userId } = await req.json()
+    if (!userId) {
+      return NextResponse.json({ error: 'Missing userId' }, { status: 400 })
+    }
+
+    const supabase = getSupabaseAdmin()
+    const bucket = 'user-uploads'
+
+    // Ensure bucket exists
+    const { data: bucketInfo } = await supabase.storage.getBucket(bucket)
+    if (!bucketInfo) {
+      await supabase.storage.createBucket(bucket, { public: true })
+    }
+
+    const filePath = `${userId}/.keep`
+    const { error: uploadError } = await supabase.storage
+      .from(bucket)
+      .upload(filePath, Buffer.from('init'), { upsert: false, contentType: 'text/plain' })
+
+    if (uploadError && !uploadError.message.includes('exists')) {
+      return NextResponse.json({ error: uploadError.message }, { status: 500 })
+    }
+
+    return NextResponse.json({ ok: true })
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e)
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -10,7 +10,12 @@ export default function CallbackPage() {
     const recover = async () => {
       const { data, error } = await supabase.auth.getSession()
       if (data.session) {
-        router.push('/') // 🔄 Now goes to homepage
+        await fetch('/api/create-user-folder', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ userId: data.session.user.id })
+        })
+        router.push('/')
       } else {
         console.error('Recovery failed:', error?.message)
         router.push('/auth/login')

--- a/src/app/auth/register/components/RegisterForm.tsx
+++ b/src/app/auth/register/components/RegisterForm.tsx
@@ -45,7 +45,8 @@ export default function RegisterComponent({ t = defaultT }: RegisterProps) {
   const router = useRouter()
   const searchParams = useSearchParams()
   const lang = searchParams.get('lang') || 'es'
-  const postAuthRedirect = searchParams.get('redirectTo') || '/'  // Added for flexibility, mirroring login
+  // Added for flexibility, mirroring login
+  const postAuthRedirect = searchParams.get('redirectTo') || '/'
 
   const handleRegister = async () => {
     setLoading(true)
@@ -55,12 +56,20 @@ export default function RegisterComponent({ t = defaultT }: RegisterProps) {
       email,
       password,
       options: {
-        data: { 
+        data: {
           full_name: email.split('@')[0],
           locale: lang
         }
       }
     })
+
+    if (!error && data?.user) {
+      await fetch('/api/create-user-folder', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId: data.user.id })
+      })
+    }
 
     if (error) {
       setError(error.message)

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,132 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import Image from 'next/image'
+import { FiEdit2 } from 'react-icons/fi'
+import { supabase } from '@/lib/supabaseClient'
+import useUser from '@/features/auth/useUser'
+
+export default function SettingsPage() {
+  const user = useUser()
+  const [fullName, setFullName] = useState('')
+  const [avatarUrl, setAvatarUrl] = useState('')
+  const [phone, setPhone] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [uploading, setUploading] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    const loadProfile = async () => {
+      if (!user) return
+      setAvatarUrl(user.user_metadata?.avatar_url || '')
+      setPhone(user.user_metadata?.phone || '')
+      const { data } = await supabase
+        .from('api.profiles')
+        .select('full_name')
+        .eq('id', user.id)
+        .single()
+      if (data?.full_name) setFullName(data.full_name)
+    }
+    loadProfile()
+  }, [user])
+
+  const handleSave = async () => {
+    if (!user) return
+    setSaving(true)
+    await supabase.auth.updateUser({ data: { full_name: fullName, avatar_url: avatarUrl, phone } })
+    await supabase.from('api.profiles').upsert({ id: user.id, full_name: fullName })
+    setSaving(false)
+  }
+
+  const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!user) return
+    const file = e.target.files?.[0]
+    if (!file) return
+    setUploading(true)
+    const ext = file.name.split('.').pop()
+    const filePath = `${user.id}/avatar.${ext}`
+    const { error } = await supabase.storage.from('user-uploads').upload(filePath, file, { upsert: true })
+    if (!error) {
+      const { data } = supabase.storage.from('user-uploads').getPublicUrl(filePath)
+      setAvatarUrl(data.publicUrl)
+      await supabase.auth.updateUser({ data: { avatar_url: data.publicUrl } })
+    }
+    setUploading(false)
+  }
+
+  if (!user) return <div className="p-6">Loading...</div>
+
+  return (
+    <div className="max-w-xl mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-6">Personal info</h1>
+      <div className="bg-white rounded-xl shadow p-6 space-y-6">
+        <div className="flex items-center gap-6">
+          <div className="relative">
+            <Image
+              src={avatarUrl || '/images/user/user-placeholder.png'}
+              alt="Avatar"
+              width={96}
+              height={96}
+              className="rounded-full object-cover"
+            />
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="absolute bottom-0 right-0 bg-gray-800 text-white p-2 rounded-full hover:bg-gray-700"
+            >
+              <FiEdit2 className="w-4 h-4" />
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              onChange={handleUpload}
+              disabled={uploading}
+              className="hidden"
+            />
+          </div>
+          <div>
+            <p className="text-sm text-gray-500">Photo</p>
+            <p className="text-xs text-gray-400">A photo helps personalize your account.</p>
+          </div>
+        </div>
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">Full name</label>
+            <input
+              type="text"
+              value={fullName}
+              onChange={(e) => setFullName(e.target.value)}
+              className="w-full border rounded px-3 py-2"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Phone number</label>
+            <input
+              type="tel"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              className="w-full border rounded px-3 py-2"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Email</label>
+            <input
+              type="text"
+              value={user.email}
+              disabled
+              className="w-full border rounded px-3 py-2 bg-gray-100"
+            />
+          </div>
+        </div>
+        <button
+          onClick={handleSave}
+          disabled={saving}
+          className="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded"
+        >
+          {saving ? 'Saving...' : 'Save'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/layout/UserMenu.tsx
+++ b/src/components/layout/UserMenu.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect } from 'react'
 import Image from 'next/image'
+import Link from 'next/link'
 import { supabase } from '@/lib/supabaseClient'
 import { useRouter } from 'next/navigation'
 import { User } from '@supabase/supabase-js'
@@ -34,7 +35,7 @@ export default function UserMenu({ user, locale }: Props) {
 
     const handleLogout = async () => {
         await supabase.auth.signOut()
-        router.push('/') // redirect to homepage after logout
+        router.push('/')
     }
 
     useEffect(() => {
@@ -138,10 +139,14 @@ export default function UserMenu({ user, locale }: Props) {
 
                 {/* Settings - Centered */}
                 <div className="px-5 pt-3">
-                    <div className="flex flex-col items-center justify-center hover:bg-gray-100 rounded-xl transition transform hover:scale-105 py-4 cursor-pointer">
+                    <Link
+                        href="/settings"
+                        onClick={() => setOpen(false)}
+                        className="flex flex-col items-center justify-center hover:bg-gray-100 rounded-xl transition transform hover:scale-105 py-4"
+                    >
                         <Image src="/images/user/user-settings.png" alt={settingsAlt} width={28} height={28} />
                         <span className="text-sm font-semibold mt-1">{settingsText}</span>
-                    </div>
+                    </Link>
                 </div>
 
                 {/* Logout */}


### PR DESCRIPTION
## Summary
- link settings page from user menu
- create API route to initialize per-user storage folder in Supabase
- add UI for editing profile and uploading avatar with phone number field
- clean up leftover comments in auth flow and user menu

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899dbb7e2108326a36f50d8a4d0b0b9