### PR TITLE
feat: enhance settings page with avatar sync

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,16 +1,50 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
 import Image from 'next/image'
-import { FiEdit2 } from 'react-icons/fi'
+import { FiEdit2, FiCheckCircle } from 'react-icons/fi'
+import Navbar from '@/components/layout/Navbar'
 import { supabase } from '@/lib/supabaseClient'
 import useUser from '@/features/auth/useUser'
 
 export default function SettingsPage() {
+  const searchParams = useSearchParams()
+  const langParam = searchParams.get('lang')
+  const router = useRouter()
+
+  const [locale, setLocale] = useState<'en' | 'es'>('en')
+  useEffect(() => {
+    if (langParam === 'es' || langParam === 'en') {
+      setLocale(langParam)
+    } else {
+      const browserLang = navigator.language.toLowerCase().startsWith('es') ? 'es' : 'en'
+      setLocale(browserLang)
+    }
+  }, [langParam])
+
+  const toggleLocale = () => {
+    const newLocale = locale === 'es' ? 'en' : 'es'
+    setLocale(newLocale)
+    const currentPath = window.location.pathname
+    window.location.href = `${currentPath}?lang=${newLocale}`
+  }
+
+  const t = {
+    howItWorks: locale === 'es' ? 'Cómo funciona' : 'How it works',
+    login: locale === 'es' ? 'Iniciar sesión' : 'Log In',
+    signup: locale === 'es' ? 'Crear cuenta' : 'Sign Up',
+    searchPlaceholder: locale === 'es' ? 'Buscar servicio...' : 'Search service...',
+    language: locale === 'es' ? 'Español' : 'English',
+    joinAsPro: locale === 'es' ? 'Unirse como proveedor' : 'Join as provider',
+  }
+
   const user = useUser()
   const [fullName, setFullName] = useState('')
   const [avatarUrl, setAvatarUrl] = useState('')
   const [phone, setPhone] = useState('')
+  const [address, setAddress] = useState('')
+  const [city, setCity] = useState('')
   const [saving, setSaving] = useState(false)
   const [uploading, setUploading] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -19,13 +53,15 @@ export default function SettingsPage() {
     const loadProfile = async () => {
       if (!user) return
       setAvatarUrl(user.user_metadata?.avatar_url || '')
-      setPhone(user.user_metadata?.phone || '')
       const { data } = await supabase
         .from('api.profiles')
-        .select('full_name')
+        .select('full_name, phone, address, city')
         .eq('id', user.id)
         .single()
-      if (data?.full_name) setFullName(data.full_name)
+      setFullName(data?.full_name || user.user_metadata?.name || '')
+      setPhone(data?.phone || user.user_metadata?.phone || '')
+      setAddress(data?.address || user.user_metadata?.address || '')
+      setCity(data?.city || user.user_metadata?.city || '')
     }
     loadProfile()
   }, [user])
@@ -33,8 +69,18 @@ export default function SettingsPage() {
   const handleSave = async () => {
     if (!user) return
     setSaving(true)
-    await supabase.auth.updateUser({ data: { full_name: fullName, avatar_url: avatarUrl, phone } })
-    await supabase.from('api.profiles').upsert({ id: user.id, full_name: fullName })
+    await supabase.auth.updateUser({
+      data: { avatar_url: avatarUrl, name: fullName, phone, address, city },
+    })
+    await supabase.from('api.profiles').upsert({
+      id: user.id,
+      full_name: fullName,
+      phone,
+      address,
+      city,
+    })
+    await supabase.auth.refreshSession()
+    router.refresh()
     setSaving(false)
   }
 
@@ -45,88 +91,204 @@ export default function SettingsPage() {
     setUploading(true)
     const ext = file.name.split('.').pop()
     const filePath = `${user.id}/avatar.${ext}`
-    const { error } = await supabase.storage.from('user-uploads').upload(filePath, file, { upsert: true })
+    const { error } = await supabase.storage
+      .from('users-data')
+      .upload(filePath, file, { upsert: true })
     if (!error) {
-      const { data } = supabase.storage.from('user-uploads').getPublicUrl(filePath)
+      const { data } = supabase.storage.from('users-data').getPublicUrl(filePath)
       setAvatarUrl(data.publicUrl)
       await supabase.auth.updateUser({ data: { avatar_url: data.publicUrl } })
+      await supabase.auth.refreshSession()
+      router.refresh()
     }
     setUploading(false)
   }
 
-  if (!user) return <div className="p-6">Loading...</div>
+  const pageT = {
+    personalInfo: locale === 'es' ? 'Información personal' : 'Personal info',
+    photo: locale === 'es' ? 'Foto' : 'Photo',
+    photoHelp:
+      locale === 'es'
+        ? 'Una foto ayuda a personalizar tu cuenta.'
+        : 'A photo helps personalize your account.',
+    name: locale === 'es' ? 'Nombre' : 'Name',
+    phone: locale === 'es' ? 'Teléfono' : 'Phone number',
+    address: locale === 'es' ? 'Dirección' : 'Address',
+    city: locale === 'es' ? 'Ciudad' : 'City',
+    email: locale === 'es' ? 'Correo electrónico' : 'Email',
+    verified: locale === 'es' ? 'Verificado' : 'Verified',
+    update: locale === 'es' ? 'Actualizar' : 'Update',
+    updating: locale === 'es' ? 'Actualizando...' : 'Updating...',
+    placeholderName:
+      locale === 'es' ? 'Tu nombre completo' : 'Your full name',
+    placeholderPhone: '+549...',
+    placeholderAddress:
+      locale === 'es' ? 'Tu dirección' : 'Your address',
+    placeholderCity: locale === 'es' ? 'Tu ciudad' : 'Your city',
+    loading: locale === 'es' ? 'Cargando...' : 'Loading...',
+  }
+
+  if (!user)
+    return (
+      <>
+        <Navbar locale={locale} toggleLocale={toggleLocale} t={t} forceWhite />
+        <div className="bg-white min-h-screen pt-32">
+          <div className="max-w-6xl mx-auto px-6 py-8">{pageT.loading}</div>
+        </div>
+      </>
+    )
 
   return (
-    <div className="max-w-xl mx-auto p-6">
-      <h1 className="text-2xl font-bold mb-6">Personal info</h1>
-      <div className="bg-white rounded-xl shadow p-6 space-y-6">
-        <div className="flex items-center gap-6">
-          <div className="relative">
-            <Image
-              src={avatarUrl || '/images/user/user-placeholder.png'}
-              alt="Avatar"
-              width={96}
-              height={96}
-              className="rounded-full object-cover"
+    <>
+      <Navbar locale={locale} toggleLocale={toggleLocale} t={t} forceWhite />
+      <div className="bg-white min-h-screen pt-32">
+        <div className="max-w-6xl mx-auto px-6 py-8">
+          <h1 className="text-3xl font-bold tracking-tight mb-6">{pageT.personalInfo}</h1>
+
+          <div className="bg-white rounded-2xl shadow-sm border">
+            <div className="p-6 flex items-center gap-6">
+            <div className="relative">
+              <Image
+                src={avatarUrl || '/images/user/user-placeholder.png'}
+                alt="Avatar"
+                width={96}
+                height={96}
+                className="rounded-full object-cover ring-1 ring-black/5"
+              />
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="absolute -bottom-1 -right-1 bg-gray-900 text-white p-2 rounded-full hover:bg-gray-800"
+                title="Change photo"
+              >
+                <FiEdit2 className="w-4 h-4" />
+              </button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                onChange={handleUpload}
+                disabled={uploading}
+                className="hidden"
+              />
+            </div>
+            <div className="space-y-1">
+              <p className="text-sm text-gray-800">{pageT.photo}</p>
+              <p className="text-xs text-gray-600">{pageT.photoHelp}</p>
+            </div>
+          </div>
+
+          <hr className="border-t" />
+
+          <div className="divide-y">
+            <Row
+              label={pageT.name}
+              rightEl={
+                <div className="w-full sm:w-[560px]">
+                  <input
+                    type="text"
+                    value={fullName}
+                    onChange={(e) => setFullName(e.target.value)}
+                    className="w-full border rounded-lg px-3 py-2"
+                    placeholder={pageT.placeholderName}
+                  />
+                </div>
+              }
             />
+
+            <Row
+              label={pageT.phone}
+              rightEl={
+                <div className="flex items-center gap-3 w-full sm:w-[560px]">
+                  <input
+                    type="tel"
+                    value={phone}
+                    onChange={(e) => setPhone(e.target.value)}
+                    className="flex-1 border rounded-lg px-3 py-2"
+                    placeholder={pageT.placeholderPhone}
+                  />
+                  {!!phone && (
+                    <FiCheckCircle className="text-green-600 shrink-0" title={pageT.verified} />
+                  )}
+                </div>
+              }
+            />
+
+            <Row
+              label={pageT.address}
+              rightEl={
+                <div className="w-full sm:w-[560px]">
+                  <input
+                    type="text"
+                    value={address}
+                    onChange={(e) => setAddress(e.target.value)}
+                    className="w-full border rounded-lg px-3 py-2"
+                    placeholder={pageT.placeholderAddress}
+                  />
+                </div>
+              }
+            />
+
+            <Row
+              label={pageT.city}
+              rightEl={
+                <div className="w-full sm:w-[560px]">
+                  <input
+                    type="text"
+                    value={city}
+                    onChange={(e) => setCity(e.target.value)}
+                    className="w-full border rounded-lg px-3 py-2"
+                    placeholder={pageT.placeholderCity}
+                  />
+                </div>
+              }
+            />
+
+            <Row
+              label={pageT.email}
+              rightEl={
+                <div className="flex items-center gap-3 w-full sm:w-[560px]">
+                  <input
+                    type="text"
+                    value={user.email}
+                    disabled
+                    className="flex-1 border rounded-lg px-3 py-2 bg-gray-100"
+                  />
+                  <FiCheckCircle className="text-green-600 shrink-0" title={pageT.verified} />
+                </div>
+              }
+            />
+          </div>
+
+          <div className="p-6">
             <button
-              type="button"
-              onClick={() => fileInputRef.current?.click()}
-              className="absolute bottom-0 right-0 bg-gray-800 text-white p-2 rounded-full hover:bg-gray-700"
+              onClick={handleSave}
+              disabled={saving}
+              className="bg-black hover:bg-gray-800 disabled:opacity-60 text-white px-4 py-2 rounded-lg"
             >
-              <FiEdit2 className="w-4 h-4" />
+              {saving ? pageT.updating : pageT.update}
             </button>
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="image/*"
-              onChange={handleUpload}
-              disabled={uploading}
-              className="hidden"
-            />
-          </div>
-          <div>
-            <p className="text-sm text-gray-500">Photo</p>
-            <p className="text-xs text-gray-400">A photo helps personalize your account.</p>
           </div>
         </div>
-        <div className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium mb-1">Full name</label>
-            <input
-              type="text"
-              value={fullName}
-              onChange={(e) => setFullName(e.target.value)}
-              className="w-full border rounded px-3 py-2"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Phone number</label>
-            <input
-              type="tel"
-              value={phone}
-              onChange={(e) => setPhone(e.target.value)}
-              className="w-full border rounded px-3 py-2"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Email</label>
-            <input
-              type="text"
-              value={user.email}
-              disabled
-              className="w-full border rounded px-3 py-2 bg-gray-100"
-            />
-          </div>
-        </div>
-        <button
-          onClick={handleSave}
-          disabled={saving}
-          className="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded"
-        >
-          {saving ? 'Saving...' : 'Save'}
-        </button>
       </div>
+    </div>
+    </>
+  )
+}
+
+function Row({
+  label,
+  rightEl,
+}: {
+  label: string
+  rightEl: React.ReactNode
+}) {
+  return (
+    <div className="p-6 flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-8">
+      <div className="w-40 shrink-0 text-sm text-gray-800">{label}</div>
+      <div className="flex-1">{rightEl}</div>
+      <div className="hidden sm:block text-gray-400">{'›'}</div>
     </div>
   )
 }
+


### PR DESCRIPTION
## Summary
- sync external avatars to `users-data` storage and refresh user menu
- expand settings form with address and city fields and localized labels
- restyle update button and remove language option on white background

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899e5c5d55c8326955f209c2c971ca6