### PR TITLE
feat: enforce dark mode styling on auth pages

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -25,5 +25,5 @@ export default function CallbackPage() {
     recover()
   }, [router])
 
-  return <div className="p-6">Restaurando sesión...</div>
+  return <div className="p-6 text-center text-gray-200">Restaurando sesión...</div>
 }

--- a/src/app/auth/forgot-password/components/ForgotPasswordForm.tsx
+++ b/src/app/auth/forgot-password/components/ForgotPasswordForm.tsx
@@ -59,17 +59,17 @@ export default function ForgotPasswordComponent({
   }
 
   return (
-    <div className="w-full max-w-md bg-white/90 dark:bg-gray-800/90 backdrop-blur-sm rounded-2xl shadow-xl p-8 border border-gray-200/60 dark:border-gray-700 text-gray-900 dark:text-white">
-        <h2 className="text-2xl font-extrabold text-center text-gray-900 dark:text-white mb-6">
+    <div className="w-full max-w-md bg-gray-800/90 backdrop-blur-sm rounded-2xl shadow-xl p-8 border border-gray-700 text-white">
+        <h2 className="text-2xl font-extrabold text-center text-white mb-6">
           {t?.title}
         </h2>
 
-        <p className="text-sm text-gray-600 dark:text-gray-400 text-center mb-6">
+        <p className="text-sm text-gray-400 text-center mb-6">
           {t?.description}
         </p>
 
         <div className="mb-4">
-          <label className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">
+          <label className="block text-sm font-semibold text-gray-300 mb-1">
             {t?.email}
           </label>
           <div className="relative">
@@ -78,14 +78,14 @@ export default function ForgotPasswordComponent({
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="w-full pl-10 pr-3 py-2 border border-gray-300 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-900 dark:text-white"
+              className="w-full pl-10 pr-3 py-2 border border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 bg-gray-900 text-white"
               placeholder="you@example.com"
             />
           </div>
         </div>
 
         {error && <p className="text-red-500 text-sm mb-4 text-center">❌ {error}</p>}
-        {success && <p className="text-green-600 text-sm mb-4 text-center">{success}</p>}
+        {success && <p className="text-green-400 text-sm mb-4 text-center">{success}</p>}
 
         <button
           onClick={handleResetPassword}
@@ -96,9 +96,9 @@ export default function ForgotPasswordComponent({
           {loading ? t?.sending : t?.sendResetLink}
         </button>
 
-        <div className="text-center text-sm text-gray-600 dark:text-gray-400 mt-6">
+        <div className="text-center text-sm text-gray-400 mt-6">
           {t?.loginRedirect}{' '}
-          <a href={`/auth/login?lang=${locale}`} className="text-blue-600 hover:underline dark:text-blue-400">
+          <a href={`/auth/login?lang=${locale}`} className="text-blue-400 hover:underline">
             {t?.backToLogin}
           </a>
         </div>

--- a/src/app/auth/forgot-password/page.tsx
+++ b/src/app/auth/forgot-password/page.tsx
@@ -3,7 +3,7 @@ import ForgotPasswordClient from './components/ForgotPasswordClient'
 
 export default function ForgotPasswordPage() {
   return (
-    <Suspense fallback={<div className="p-6 text-center text-gray-600">Loading...</div>}>
+    <Suspense fallback={<div className="p-6 text-center text-gray-400">Loading...</div>}>
       <ForgotPasswordClient />
     </Suspense>
   )

--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react'
 
 export default function AuthLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-rose-400 via-red-500 to-fuchsia-500 dark:from-gray-900 dark:via-gray-900 dark:to-black p-4">
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-gray-900 via-gray-900 to-black p-4 text-gray-100">
       <Link href="/" className="mb-8" aria-label="Home">
         <Image src="/logo/presu-03.png" alt="Presu logo" width={120} height={40} priority />
       </Link>

--- a/src/app/auth/login/components/LoginForm.tsx
+++ b/src/app/auth/login/components/LoginForm.tsx
@@ -81,11 +81,11 @@ export default function LoginComponent({ locale = 'en', t = defaultT }: LoginCom
   }
 
   return (
-    <div className="w-full max-w-md bg-white/90 dark:bg-gray-800/90 backdrop-blur-sm rounded-2xl shadow-xl p-8 space-y-6 border border-gray-200/60 dark:border-gray-700">
-        <h2 className="text-2xl font-extrabold text-center mb-2">
+    <div className="w-full max-w-md bg-gray-800/90 backdrop-blur-sm rounded-2xl shadow-xl p-8 space-y-6 border border-gray-700">
+        <h2 className="text-2xl font-extrabold text-center text-white mb-2">
           {t.loginTo}
         </h2>
-        <p className="text-sm text-center text-gray-600 dark:text-gray-400">
+        <p className="text-sm text-center text-gray-400">
           {t.noAccount}{' '}
           <a
             href={`/auth/register?lang=${lang}`}
@@ -97,7 +97,7 @@ export default function LoginComponent({ locale = 'en', t = defaultT }: LoginCom
 
         <button
           onClick={handleGoogleLogin}
-          className="w-full flex items-center justify-center gap-2 bg-white text-black border border-gray-300 px-4 py-2 rounded-lg hover:bg-gray-50 transition disabled:opacity-50 text-sm font-medium"
+          className="w-full flex items-center justify-center gap-2 bg-gray-700 text-white border border-gray-600 px-4 py-2 rounded-lg hover:bg-gray-600 transition disabled:opacity-50 text-sm font-medium"
           disabled={googleLoading}
         >
           {googleLoading && <span className="loader border-blue-500" />}
@@ -106,14 +106,14 @@ export default function LoginComponent({ locale = 'en', t = defaultT }: LoginCom
         </button>
 
         <div className="relative text-center">
-          <span className="text-xs text-gray-400 px-2 bg-white dark:bg-gray-800 z-10 relative">
+          <span className="text-xs text-gray-400 px-2 bg-gray-800 z-10 relative">
             {t.orLoginWithEmail}
           </span>
-          <div className="absolute top-1/2 left-0 w-full border-t border-gray-300 dark:border-gray-600 -z-0 transform -translate-y-1/2" />
+          <div className="absolute top-1/2 left-0 w-full border-t border-gray-600 -z-0 transform -translate-y-1/2" />
         </div>
 
         <div className="text-left">
-          <label className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">
+          <label className="block text-sm font-semibold text-gray-300 mb-1">
             {t.email}
           </label>
           <div className="relative">
@@ -123,13 +123,13 @@ export default function LoginComponent({ locale = 'en', t = defaultT }: LoginCom
               placeholder={t.email}
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="w-full pl-10 pr-3 py-2 border border-gray-300 dark:border-gray-700 rounded-lg bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-red-500 text-sm"
+              className="w-full pl-10 pr-3 py-2 border border-gray-700 rounded-lg bg-gray-900 text-white focus:outline-none focus:ring-2 focus:ring-red-500 text-sm"
             />
           </div>
         </div>
 
         <div className="text-left">
-          <label className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">
+          <label className="block text-sm font-semibold text-gray-300 mb-1">
             {t.password}
           </label>
           <div className="relative">
@@ -139,7 +139,7 @@ export default function LoginComponent({ locale = 'en', t = defaultT }: LoginCom
               placeholder={t.password}
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="w-full pl-10 pr-3 py-2 border border-gray-300 dark:border-gray-700 rounded-lg bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-red-500 text-sm"
+              className="w-full pl-10 pr-3 py-2 border border-gray-700 rounded-lg bg-gray-900 text-white focus:outline-none focus:ring-2 focus:ring-red-500 text-sm"
             />
           </div>
         </div>

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -3,7 +3,7 @@ import LoginPageClient from './components/LoginClient'
 
 export default function LoginPage() {
   return (
-    <Suspense fallback={<div className="p-6 text-center text-gray-600">Loading...</div>}>
+    <Suspense fallback={<div className="p-6 text-center text-gray-400">Loading...</div>}>
       <LoginPageClient />
     </Suspense>
   )

--- a/src/app/auth/register/components/RegisterForm.tsx
+++ b/src/app/auth/register/components/RegisterForm.tsx
@@ -99,11 +99,11 @@ export default function RegisterComponent({ t = defaultT }: RegisterProps) {
   }
 
   return (
-    <div className="w-full max-w-md bg-white/90 dark:bg-gray-800/90 backdrop-blur-sm rounded-2xl shadow-xl p-8 space-y-6 border border-gray-200/60 dark:border-gray-700">
-        <h2 className="text-2xl font-extrabold text-center mb-2">
+    <div className="w-full max-w-md bg-gray-800/90 backdrop-blur-sm rounded-2xl shadow-xl p-8 space-y-6 border border-gray-700">
+        <h2 className="text-2xl font-extrabold text-center text-white mb-2">
           {t.createAccount}
         </h2>
-        <p className="text-sm text-center text-gray-600 dark:text-gray-400">
+        <p className="text-sm text-center text-gray-400">
           {t.alreadyHaveAccount}{' '}
           <a
             href={`/auth/login${lang ? `?lang=${lang}` : ''}`}
@@ -116,7 +116,7 @@ export default function RegisterComponent({ t = defaultT }: RegisterProps) {
         {/* Google Signup */}
         <button
           onClick={handleGoogleSignup}
-          className="w-full flex items-center justify-center gap-2 bg-white text-black border border-gray-300 px-4 py-2 rounded-lg hover:bg-gray-50 transition disabled:opacity-50 text-sm font-medium"
+          className="w-full flex items-center justify-center gap-2 bg-gray-700 text-white border border-gray-600 px-4 py-2 rounded-lg hover:bg-gray-600 transition disabled:opacity-50 text-sm font-medium"
           disabled={googleLoading}
         >
           {googleLoading && <span className="loader border-blue-500" />}
@@ -126,15 +126,15 @@ export default function RegisterComponent({ t = defaultT }: RegisterProps) {
 
         {/* Divider */}
         <div className="relative text-center">
-          <span className="text-xs text-gray-400 px-2 bg-white dark:bg-gray-800 z-10 relative">
+          <span className="text-xs text-gray-400 px-2 bg-gray-800 z-10 relative">
             {t.orSignupWithEmail}
           </span>
-          <div className="absolute top-1/2 left-0 w-full border-t border-gray-300 dark:border-gray-600 -z-0 transform -translate-y-1/2" />
+          <div className="absolute top-1/2 left-0 w-full border-t border-gray-600 -z-0 transform -translate-y-1/2" />
         </div>
 
         {/* Email input */}
         <div className="text-left">
-          <label className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">
+          <label className="block text-sm font-semibold text-gray-300 mb-1">
             {t.email}
           </label>
           <div className="relative">
@@ -144,14 +144,14 @@ export default function RegisterComponent({ t = defaultT }: RegisterProps) {
               placeholder={t.email}
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="w-full pl-10 pr-3 py-2 border border-gray-300 dark:border-gray-700 rounded-lg bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-red-500 text-sm"
+              className="w-full pl-10 pr-3 py-2 border border-gray-700 rounded-lg bg-gray-900 text-white focus:outline-none focus:ring-2 focus:ring-red-500 text-sm"
             />
           </div>
         </div>
 
         {/* Password input */}
         <div className="text-left">
-          <label className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">
+          <label className="block text-sm font-semibold text-gray-300 mb-1">
             {t.password}
           </label>
           <div className="relative">
@@ -161,7 +161,7 @@ export default function RegisterComponent({ t = defaultT }: RegisterProps) {
               placeholder={t.password}
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="w-full pl-10 pr-3 py-2 border border-gray-300 dark:border-gray-700 rounded-lg bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-red-500 text-sm"
+              className="w-full pl-10 pr-3 py-2 border border-gray-700 rounded-lg bg-gray-900 text-white focus:outline-none focus:ring-2 focus:ring-red-500 text-sm"
             />
           </div>
         </div>

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -3,7 +3,7 @@ import RegisterPageClient from './components/RegisterClient'
 
 export default function RegisterPage() {
   return (
-    <Suspense fallback={<div className="p-6 text-center text-gray-600">Loading...</div>}>
+    <Suspense fallback={<div className="p-6 text-center text-gray-400">Loading...</div>}>
       <RegisterPageClient />
     </Suspense>
   )


### PR DESCRIPTION
## Summary
- ensure auth layout and forms default to dark mode with dark backgrounds and light text
- darken Google buttons and dividers across login, register, and password reset screens
- update loading and callback screens to use dark-friendly colors

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a078c55ac8326a7a89a9ff578a169