### PR TITLE
Ensure default avatar is set for new users

### DIFF
--- a/src/app/auth/register/components/RegisterForm.tsx
+++ b/src/app/auth/register/components/RegisterForm.tsx
@@ -58,7 +58,8 @@ export default function RegisterComponent({ t = defaultT }: RegisterProps) {
       options: {
         data: {
           full_name: email.split('@')[0],
-          locale: lang
+          locale: lang,
+          avatar_url: '/images/user/user-placeholder.png'
         }
       }
     })

--- a/src/features/auth/useUser.ts
+++ b/src/features/auth/useUser.ts
@@ -29,9 +29,18 @@ export default function useUser() {
 
   useEffect(() => {
     const syncAvatar = async () => {
+      if (user && !user.user_metadata?.avatar_url) {
+        await supabase.auth.updateUser({
+          data: { avatar_url: '/images/user/user-placeholder.png' },
+        })
+        await supabase.auth.refreshSession()
+        router.refresh()
+        return
+      }
       if (
         user?.user_metadata?.avatar_url &&
-        !user.user_metadata.avatar_url.includes('/storage/v1/object/public/users-data/')
+        !user.user_metadata.avatar_url.includes('/storage/v1/object/public/users-data/') &&
+        !user.user_metadata.avatar_url.startsWith('/images/')
       ) {
         try {
           const response = await fetch(user.user_metadata.avatar_url)


### PR DESCRIPTION
## Summary
- Assign placeholder avatar to email signups
- Skip avatar sync when no image or using placeholder
- Automatically create placeholder avatar when none is stored

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a09db8d548326a4fad8fa7283d33d