### PR TITLE
Ensure default avatar is set for new users

### DIFF
--- a/src/app/auth/register/components/RegisterForm.tsx
+++ b/src/app/auth/register/components/RegisterForm.tsx
@@ -58,7 +58,8 @@ export default function RegisterComponent({ t = defaultT }: RegisterProps) {
       options: {
         data: {
           full_name: email.split('@')[0],
-          locale: lang
+          locale: lang,
+          avatar_url: '/images/user/user-placeholder.png'
         }
       }
     })

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -95,9 +95,16 @@ export default function SettingsPage() {
       .from('users-data')
       .upload(filePath, file, { upsert: true })
     if (!error) {
-      const { data } = supabase.storage.from('users-data').getPublicUrl(filePath)
-      setAvatarUrl(data.publicUrl)
-      await supabase.auth.updateUser({ data: { avatar_url: data.publicUrl } })
+      const publicPath = `/storage/v1/object/public/users-data/${filePath}`
+      setAvatarUrl(publicPath)
+      await supabase.auth.updateUser({ data: { avatar_url: publicPath } })
+      await supabase.auth.refreshSession()
+      router.refresh()
+    } else {
+      setAvatarUrl('/images/user/user-placeholder.png')
+      await supabase.auth.updateUser({
+        data: { avatar_url: '/images/user/user-placeholder.png' },
+      })
       await supabase.auth.refreshSession()
       router.refresh()
     }

--- a/src/features/auth/useUser.ts
+++ b/src/features/auth/useUser.ts
@@ -29,9 +29,18 @@ export default function useUser() {
 
   useEffect(() => {
     const syncAvatar = async () => {
+      if (user && !user.user_metadata?.avatar_url) {
+        await supabase.auth.updateUser({
+          data: { avatar_url: '/images/user/user-placeholder.png' },
+        })
+        await supabase.auth.refreshSession()
+        router.refresh()
+        return
+      }
       if (
         user?.user_metadata?.avatar_url &&
-        !user.user_metadata.avatar_url.includes('/storage/v1/object/public/users-data/')
+        !user.user_metadata.avatar_url.startsWith('/storage/v1/object/public/users-data/') &&
+        !user.user_metadata.avatar_url.startsWith('/images/')
       ) {
         try {
           const response = await fetch(user.user_metadata.avatar_url)
@@ -42,13 +51,24 @@ export default function useUser() {
             .from('users-data')
             .upload(filePath, blob, { upsert: true })
           if (!error) {
-            const { data } = supabase.storage.from('users-data').getPublicUrl(filePath)
-            await supabase.auth.updateUser({ data: { avatar_url: data.publicUrl } })
+            const publicPath = `/storage/v1/object/public/users-data/${filePath}`
+            await supabase.auth.updateUser({ data: { avatar_url: publicPath } })
+            await supabase.auth.refreshSession()
+            router.refresh()
+          } else {
+            await supabase.auth.updateUser({
+              data: { avatar_url: '/images/user/user-placeholder.png' },
+            })
             await supabase.auth.refreshSession()
             router.refresh()
           }
         } catch (e) {
           console.error('Failed to sync avatar', e)
+          await supabase.auth.updateUser({
+            data: { avatar_url: '/images/user/user-placeholder.png' },
+          })
+          await supabase.auth.refreshSession()
+          router.refresh()
         }
       }
     }


### PR DESCRIPTION
## Summary
- Store uploaded avatars using relative `/storage/v1/object/public/users-data` paths
- Fall back to placeholder avatar when sync or upload fails

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a09db8d548326a4fad8fa7283d33d