### PR TITLE
Ensure placeholder avatar exists in user bucket

### DIFF
--- a/src/app/api/create-user-folder/route.ts
+++ b/src/app/api/create-user-folder/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server'
 import { getSupabaseAdmin } from '@/lib/supabaseAdmin'
+import { readFile } from 'fs/promises'
+import path from 'path'
 
 export const runtime = 'nodejs'
 
@@ -11,7 +13,9 @@ export async function POST(req: Request) {
     }
 
     const supabase = getSupabaseAdmin()
-    const bucket = 'user-uploads'
+    // All user uploads live in the public "users-data" bucket so
+    // ensure that bucket and a folder for this user exist.
+    const bucket = 'users-data'
 
     // Ensure bucket exists
     const { data: bucketInfo } = await supabase.storage.getBucket(bucket)
@@ -19,13 +23,35 @@ export async function POST(req: Request) {
       await supabase.storage.createBucket(bucket, { public: true })
     }
 
-    const filePath = `${userId}/.keep`
+    const keepFilePath = `${userId}/.keep`
     const { error: uploadError } = await supabase.storage
       .from(bucket)
-      .upload(filePath, Buffer.from('init'), { upsert: false, contentType: 'text/plain' })
+      .upload(keepFilePath, Buffer.from('init'), {
+        upsert: false,
+        contentType: 'text/plain',
+      })
 
     if (uploadError && !uploadError.message.includes('exists')) {
       return NextResponse.json({ error: uploadError.message }, { status: 500 })
+    }
+
+    const placeholder = 'user-placeholder.png'
+    const { data: files } = await supabase.storage.from(bucket).list(userId)
+    const hasPlaceholder = files?.some((f) => f.name === placeholder)
+
+    if (!hasPlaceholder) {
+      const fileBuffer = await readFile(
+        path.join(process.cwd(), 'public', 'images', 'user', placeholder)
+      )
+      const { error: placeholderError } = await supabase.storage
+        .from(bucket)
+        .upload(`${userId}/${placeholder}`, fileBuffer, {
+          upsert: false,
+          contentType: 'image/png',
+        })
+      if (placeholderError && !placeholderError.message.includes('exists')) {
+        return NextResponse.json({ error: placeholderError.message }, { status: 500 })
+      }
     }
 
     return NextResponse.json({ ok: true })

--- a/src/app/auth/login/components/LoginForm.tsx
+++ b/src/app/auth/login/components/LoginForm.tsx
@@ -46,18 +46,25 @@ export default function LoginComponent({ locale = 'en', t = defaultT }: LoginCom
 
   const router = useRouter()
   const searchParams = useSearchParams()
-  const postAuthRedirect = searchParams.get('redirectTo') || '/'  // Renamed for clarity; used after successful login
+  const postAuthRedirect = searchParams.get('redirectTo') || '/'
   const lang = searchParams.get('lang') || locale
 
   const handleLogin = async () => {
     setLoading(true)
     setError(null)
 
-    const { error } = await supabase.auth.signInWithPassword({ email, password })
+    const { data, error } = await supabase.auth.signInWithPassword({ email, password })
 
     if (error) {
       setError(error.message)
     } else {
+      if (data.user) {
+        await fetch('/api/create-user-folder', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ userId: data.user.id }),
+        })
+      }
       router.push(postAuthRedirect)
     }
 


### PR DESCRIPTION
## Summary
- Align user-folder initialization with the shared `users-data` bucket and seed missing placeholder avatars
- Ensure email login triggers the user-folder creation endpoint so existing users also get a default avatar

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a0cd3b41883269f01ab05420a8bd7