### PR TITLE
fix: prefix avatar url with supabase domain

### DIFF
--- a/src/components/layout/UserMenu.tsx
+++ b/src/components/layout/UserMenu.tsx
@@ -20,7 +20,13 @@ export default function UserMenu({ user, locale }: Props) {
     const router = useRouter()
 
     const userName = user?.user_metadata?.name || user?.email?.split('@')[0] || (locale === 'en' ? 'User' : 'Usuario')
-    const avatarUrl = user?.user_metadata?.avatar_url || '/images/user/user-placeholder.png'
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || ''
+    const rawAvatarUrl = user?.user_metadata?.avatar_url
+    const avatarUrl = rawAvatarUrl
+        ? rawAvatarUrl.startsWith('http')
+            ? rawAvatarUrl
+            : `${supabaseUrl}${rawAvatarUrl}`
+        : '/images/user/user-placeholder.png'
 
     const activityText = locale === 'en' ? 'Activity' : 'Actividad'
     const activityAlt = locale === 'en' ? 'Activity' : 'Actividad'


### PR DESCRIPTION
## Summary
- fix Supabase profile image loading by prefixing the stored avatar path with the Supabase URL

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a15d4a1a483268b1bca2e0dff813c