### PR TITLE
Use signed URLs for private user avatars

### DIFF
--- a/src/features/auth/useUser.ts
+++ b/src/features/auth/useUser.ts
@@ -29,30 +29,13 @@ export default function useUser() {
 
   useEffect(() => {
     const syncAvatar = async () => {
+      if (!user) return
       const bucket = 'users-data'
-      const placeholderPath = `${user?.id}/user-placeholder.png`
+      const placeholderUrl = '/images/user/user-placeholder.png'
+      const url = user.user_metadata?.avatar_url
 
-      const isValidImageUrl = (url: string) =>
-        /\.(png|jpe?g|gif|webp)$/i.test(url)
-
-      const inUserBucket = (url: string) =>
-        url.includes(`/storage/v1/object/public/${bucket}/`)
-
-      const needsPlaceholder = () => {
-        if (!user) return false
-        const url = user.user_metadata?.avatar_url
-        if (!url) return true
-        if (url.startsWith('/images/')) return true
-        if (inUserBucket(url) && !isValidImageUrl(url)) return true
-        return false
-      }
-
-      if (needsPlaceholder()) {
-        const { data } = supabase.storage
-          .from(bucket)
-          .getPublicUrl(placeholderPath)
-        const avatarUrl = data?.publicUrl || '/images/user/user-placeholder.png'
-        await supabase.auth.updateUser({ data: { avatar_url: avatarUrl } })
+      if (!url) {
+        await supabase.auth.updateUser({ data: { avatar_url: placeholderUrl } })
         await supabase.auth.refreshSession()
         const { data: fresh } = await supabase.auth.getUser()
         if (fresh?.user) setUser(fresh.user)
@@ -60,50 +43,45 @@ export default function useUser() {
         return
       }
 
-      if (
-        user?.user_metadata?.avatar_url &&
-        !inUserBucket(user.user_metadata.avatar_url) &&
-        !user.user_metadata.avatar_url.startsWith('/images/')
-      ) {
-        try {
-          const response = await fetch(user.user_metadata.avatar_url)
-          const blob = await response.blob()
-          const ext = blob.type.split('/')[1] || 'jpg'
-          const filePath = `${user.id}/avatar.${ext}`
-          const { error } = await supabase.storage
-            .from(bucket)
-            .upload(filePath, blob, { upsert: true })
-
-          const { data } = supabase.storage
-            .from(bucket)
-            .getPublicUrl(filePath)
-          const publicUrl = data?.publicUrl
-
-          if (!error && publicUrl) {
-            await supabase.auth.updateUser({ data: { avatar_url: publicUrl } })
-          } else {
-            const { data: placeholder } = supabase.storage
-              .from(bucket)
-              .getPublicUrl(placeholderPath)
-            await supabase.auth.updateUser({ data: { avatar_url: placeholder?.publicUrl } })
-          }
-
-          await supabase.auth.refreshSession()
-          const { data: fresh } = await supabase.auth.getUser()
-          if (fresh?.user) setUser(fresh.user)
-          router.refresh()
-        } catch (e) {
-          console.error('Failed to sync avatar', e)
-          const { data: placeholder } = supabase.storage
-            .from(bucket)
-            .getPublicUrl(placeholderPath)
-          await supabase.auth.updateUser({ data: { avatar_url: placeholder?.publicUrl } })
-          await supabase.auth.refreshSession()
-          const { data: fresh } = await supabase.auth.getUser()
-          if (fresh?.user) setUser(fresh.user)
-          router.refresh()
-        }
+      const publicPrefix = `/storage/v1/object/public/${bucket}/`
+      const fullPublicPrefix = `${process.env.NEXT_PUBLIC_SUPABASE_URL || ''}${publicPrefix}`
+      if (url.startsWith(fullPublicPrefix) || url.startsWith(publicPrefix)) {
+        const filePath = url.startsWith(fullPublicPrefix)
+          ? url.slice(fullPublicPrefix.length)
+          : url.slice(publicPrefix.length)
+        await supabase.auth.updateUser({ data: { avatar_url: filePath } })
+        await supabase.auth.refreshSession()
+        const { data: fresh } = await supabase.auth.getUser()
+        if (fresh?.user) setUser(fresh.user)
+        router.refresh()
+        return
       }
+
+      if (url.startsWith('/images/') || (!url.startsWith('http') && !url.startsWith('/storage/'))) {
+        return
+      }
+
+      try {
+        const response = await fetch(url)
+        const blob = await response.blob()
+        const ext = blob.type.split('/')[1] || 'jpg'
+        const filePath = `${user.id}/avatar.${ext}`
+        const { error } = await supabase.storage
+          .from(bucket)
+          .upload(filePath, blob, { upsert: true })
+        if (!error) {
+          await supabase.auth.updateUser({ data: { avatar_url: filePath } })
+        } else {
+          await supabase.auth.updateUser({ data: { avatar_url: placeholderUrl } })
+        }
+      } catch (e) {
+        console.error('Failed to sync avatar', e)
+        await supabase.auth.updateUser({ data: { avatar_url: placeholderUrl } })
+      }
+      await supabase.auth.refreshSession()
+      const { data: fresh } = await supabase.auth.getUser()
+      if (fresh?.user) setUser(fresh.user)
+      router.refresh()
     }
     syncAvatar()
   }, [user, router])


### PR DESCRIPTION
## Summary
- Generate signed avatar URLs for private Supabase buckets in `UserMenu`
- Store avatar file paths and create signed URLs during profile updates
- Sync user avatars by converting old public URLs to bucket paths

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a17dd0a3c832694b285c16935a99c