### PR TITLE
Improve search suggestion styling and highlight matches

### DIFF
--- a/src/components/sections/home/HeroSection.tsx
+++ b/src/components/sections/home/HeroSection.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState, useRef, useCallback } from 'react'
+import type { ReactNode } from 'react'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabaseClient'
@@ -89,6 +90,48 @@ export default function HeroSection({ t, userAddress, locale }: HeroProps) {
     setShowSuggestions(true)
   }
 
+  const highlightMatch = (name: string): ReactNode => {
+    if (!searchTerm) return name
+    const lower = name.toLowerCase()
+    const term = searchTerm.toLowerCase()
+    const start = lower.indexOf(term)
+    if (start === -1) return name
+    const end = start + term.length
+    return (
+      <>
+        {name.slice(0, start)}
+        <span className="text-blue-600">{name.slice(start, end)}</span>
+        {name.slice(end)}
+      </>
+    )
+  }
+
+  const renderSuggestions = () =>
+    filteredServices.length > 0 && (
+      <ul className="absolute top-full left-0 right-0 mt-1 max-h-60 overflow-auto z-50 bg-white border border-gray-200 rounded-md shadow-lg divide-y divide-gray-100">
+        {filteredServices.map((s) => {
+          const name = locale === 'es' ? s.name_es : s.name_en
+          return (
+            <li
+              key={s.slug}
+              onPointerDown={() => handleSelect(s)}
+              className="flex items-center gap-2 px-4 py-2 text-sm cursor-pointer hover:bg-gray-50 transition-colors"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="w-4 h-4 text-gray-400"
+                viewBox="0 0 256 256"
+                fill="currentColor"
+              >
+                <path d="M229.66 218.34l-50.07-50.06a88.11 88.11 0 10-11.31 11.31l50.06 50.07a8 8 0 0011.32-11.32zM40 112a72 72 0 1172 72 72.08 72.08 0 01-72-72z" />
+              </svg>
+              <span>{highlightMatch(name)}</span>
+            </li>
+          )
+        })}
+      </ul>
+    )
+
   return (
     <section className="relative w-full h-[580px] md:h-[740px] overflow-hidden">
       {/* Rotating background images */}
@@ -141,22 +184,7 @@ export default function HeroSection({ t, userAddress, locale }: HeroProps) {
                   <path d="M128 16A88.1 88.1 0 0 0 40 104c0 66.14 80.18 131.39 83.6 134a8 8 0 0 0 8.8 0C135.82 235.39 216 170.14 216 104A88.1 88.1 0 0 0 128 16Zm0 112a24 24 0 1 1 24-24 24 24 0 0 1-24 24Z" />
                 </svg>
               </button>
-              {filteredServices.length > 0 && (
-                <div className="absolute top-full left-0 right-0 bg-white text-gray-800 shadow rounded-b-lg mt-1 max-h-60 overflow-auto z-50">
-                  {filteredServices.map((s) => {
-                    const name = locale === 'es' ? s.name_es : s.name_en
-                    return (
-                      <div
-                        key={s.slug}
-                        onPointerDown={() => handleSelect(s)}
-                        className="px-4 py-2 hover:bg-gray-100 cursor-pointer text-sm"
-                      >
-                        {name}
-                      </div>
-                    )
-                  })}
-                </div>
-              )}
+              {renderSuggestions()}
             </div>
             <button onClick={handleSearch} className="bg-black text-white rounded-full px-6 py-2 text-sm font-medium shadow hover:bg-gray-900 transition">
               {t.searchHere}
@@ -189,22 +217,7 @@ export default function HeroSection({ t, userAddress, locale }: HeroProps) {
                 }}
                 onBlur={() => setTimeout(() => setShowSuggestions(false), 100)}
               />
-              {filteredServices.length > 0 && (
-                <div className="absolute top-full left-0 right-0 bg-white text-gray-800 shadow rounded-b-lg mt-1 max-h-60 overflow-auto z-50">
-                  {filteredServices.map((s) => {
-                    const name = locale === 'es' ? s.name_es : s.name_en
-                    return (
-                      <div
-                        key={s.slug}
-                        onPointerDown={() => handleSelect(s)}
-                        className="px-4 py-2 hover:bg-gray-100 cursor-pointer text-sm"
-                      >
-                        {name}
-                      </div>
-                    )
-                  })}
-                </div>
-              )}
+              {renderSuggestions()}
             </div>
             <button className="bg-white rounded-full px-5 py-3 shadow text-sm flex items-center gap-2">
               <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4 text-gray-500" viewBox="0 0 256 256" fill="currentColor">


### PR DESCRIPTION
## Summary
- add match-highlighting helper for service suggestions
- style Intellisense dropdown with borders, dividers, icons and transitions
- reuse a shared renderSuggestions helper across search bars

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689a29bbbe2883269acba80eef834cd2