### PR TITLE
Show upcoming services on services page

### DIFF
--- a/src/app/services/ServicesClient.tsx
+++ b/src/app/services/ServicesClient.tsx
@@ -6,6 +6,75 @@ import Navbar from '@/components/layout/Navbar'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabaseClient'
 
+type Service = {
+  slug: string
+  name_es: string
+  name_en: string
+  rating?: string
+  schedule?: string
+  image_url: string
+  disabled?: boolean
+}
+
+const upcomingServices: Service[] = [
+  {
+    slug: 'air',
+    name_es: 'Aires acondicionados',
+    name_en: 'Air Conditioning',
+    image_url: '/images/services/air.jpg',
+    disabled: true
+  },
+  {
+    slug: 'brick',
+    name_es: 'Albañilería',
+    name_en: 'Masonry',
+    image_url: '/images/services/brick.jpg',
+    disabled: true
+  },
+  {
+    slug: 'electrician',
+    name_es: 'Electricista',
+    name_en: 'Electrician',
+    image_url: '/images/services/electrician.jpg',
+    disabled: true
+  },
+  {
+    slug: 'locksmith',
+    name_es: 'Cerrajería',
+    name_en: 'Locksmith',
+    image_url: '/images/services/locksmith.jpg',
+    disabled: true
+  },
+  {
+    slug: 'moving',
+    name_es: 'Mudanzas',
+    name_en: 'Moving Services',
+    image_url: '/images/services/moving.jpg',
+    disabled: true
+  },
+  {
+    slug: 'painting',
+    name_es: 'Pintura',
+    name_en: 'Painting Services',
+    image_url: '/images/services/painting.jpg',
+    disabled: true
+  },
+  {
+    slug: 'phone',
+    name_es: 'Telecomunicaciones',
+    name_en: 'Telecommunications',
+    image_url: '/images/services/phone.jpg',
+    disabled: true
+  },
+  {
+    slug: 'plumbing',
+    name_es: 'Plomería',
+    name_en: 'Plumbing',
+    image_url: '/images/services/plumbing.jpg',
+    disabled: true
+  }
+]
+
 export default function ServicesClient() {
   const [locale, setLocale] = useState<'en' | 'es'>('es')
 
@@ -34,16 +103,6 @@ export default function ServicesClient() {
     schedule: locale === 'es' ? 'Horario estimado' : 'Estimated hours',
   }
 
-  type Service = {
-    slug: string
-    name_es?: string
-    name_en?: string
-    name?: string
-    rating?: string
-    schedule?: string
-    image_url?: string
-  }
-
   const [services, setServices] = useState<Service[]>([])
 
   useEffect(() => {
@@ -52,7 +111,8 @@ export default function ServicesClient() {
         .schema('api')
         .from('services')
         .select('*')
-      if (data) setServices(data)
+      if (data) setServices([...data, ...upcomingServices])
+      else setServices(upcomingServices)
     }
     fetchServices()
   }, [])
@@ -77,23 +137,32 @@ export default function ServicesClient() {
 
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
           {services.map((s) => {
-            const name =
-              locale === 'es'
-                ? s.name_es || s.name
-                : s.name_en || s.name
+            const name = locale === 'es' ? s.name_es : s.name_en
+            const handleClick = () => {
+              if (s.disabled) {
+                router.push(`/under-construction?lang=${locale}`)
+              } else {
+                router.push(`/services/${s.slug}?lang=${locale}`)
+              }
+            }
             return (
               <div
                 key={s.slug}
-                onClick={() => router.push(`/services/${s.slug}?lang=${locale}`)}
-                className="relative rounded-lg overflow-hidden shadow hover:shadow-md transition bg-white cursor-pointer"
+                onClick={handleClick}
+                className={`relative rounded-lg overflow-hidden shadow transition bg-white ${s.disabled ? 'cursor-not-allowed opacity-70' : 'cursor-pointer hover:shadow-md'}`}
               >
                 <Image
-                  src={s.image_url || `/images/services/${s.slug}.jpg`}
-                  alt={name || s.slug}
+                  src={s.image_url}
+                  alt={name}
                   width={250}
                   height={160}
                   className="w-full h-36 sm:h-40 object-cover"
                 />
+                {s.disabled && (
+                  <div className="absolute inset-0 bg-black/60 flex items-center justify-center text-white text-sm font-semibold">
+                    {locale === 'es' ? 'Próximamente' : 'Coming Soon'}
+                  </div>
+                )}
                 <div className="px-3 py-2">
                   <h3 className="font-medium text-sm truncate">{name}</h3>
                   {(s.rating || s.schedule) && (


### PR DESCRIPTION
## Summary
- display upcoming service categories on `/services`
- disable navigation for upcoming services with a Coming Soon overlay

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a30fb372883269df7593d4249e3af