### PR TITLE
fix: stabilize user session on refresh

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -39,13 +39,13 @@ export default function Navbar({ locale, toggleLocale, t, forceWhite = false }: 
   }, [])
 
   useEffect(() => {
-    if (!user) {
+    if (user === null) {
       router.prefetch(`/auth/login?lang=${locale}`)
       router.prefetch(`/auth/register?lang=${locale}`)
     }
   }, [router, locale, user])
 
-  if (!mounted) return null
+  if (!mounted || user === undefined) return null
 
   const isLightBg = forceWhite || scrolled
   const isLightText = forceWhite || (!scrolled && !forceWhite)

--- a/src/features/auth/useUser.ts
+++ b/src/features/auth/useUser.ts
@@ -6,13 +6,13 @@ import { User } from '@supabase/supabase-js'
 import { useRouter } from 'next/navigation'
 
 export default function useUser() {
-  const [user, setUser] = useState<User | null>(null)
+  const [user, setUser] = useState<User | null | undefined>(undefined)
   const router = useRouter()
 
   useEffect(() => {
     const getUser = async () => {
-      const { data } = await supabase.auth.getUser()
-      if (data?.user) setUser(data.user)
+      const { data } = await supabase.auth.getSession()
+      setUser(data.session?.user ?? null)
     }
 
     getUser()


### PR DESCRIPTION
## Summary
- load Supabase session directly to initialize user faster
- hide navbar until user session loads to prevent logged-out flash

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8bf5cc55c8326b544d68673f3d50a