### PR TITLE
Persist Supabase session

### DIFF
--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -10,5 +10,9 @@ if (!supabaseUrl || !supabaseAnonKey) {
 }
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
-  db: { schema: 'api' }
+  db: { schema: 'api' },
+  auth: {
+    persistSession: true,
+    autoRefreshToken: true,
+  },
 })


### PR DESCRIPTION
## Summary
- enable Supabase auth to persist and refresh sessions so user logins survive closed windows

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8c3534aec83269298c48da29b10e4