### PR TITLE
Persist provider role during signup

### DIFF
--- a/src/app/auth/register/components/RegisterClient.tsx
+++ b/src/app/auth/register/components/RegisterClient.tsx
@@ -7,6 +7,7 @@ import RegisterComponent from './RegisterForm'
 export default function RegisterPageClient() {
   const searchParams = useSearchParams()
   const langParam = searchParams.get('lang')
+  const roleParam = searchParams.get('role')
 
   const [locale, setLocale] = useState<'en' | 'es'>('en')
 
@@ -46,5 +47,7 @@ export default function RegisterPageClient() {
     }
   }[locale]
 
-  return <RegisterComponent locale={locale} t={t} />
+  const role = roleParam === 'pro' ? 'provider' : 'client'
+
+  return <RegisterComponent locale={locale} role={role} t={t} />
 }

--- a/src/app/auth/register/components/RegisterForm.tsx
+++ b/src/app/auth/register/components/RegisterForm.tsx
@@ -8,6 +8,7 @@ import { FiMail, FiLock } from 'react-icons/fi'
 
 export type RegisterProps = {
   locale?: 'en' | 'es'
+  role?: 'client' | 'provider'
   t: {
     createAccount: string
     continueWithGoogle: string
@@ -35,7 +36,7 @@ const defaultT: RegisterProps['t'] = {
   login: 'Log in'
 }
 
-export default function RegisterComponent({ t = defaultT }: RegisterProps) {
+export default function RegisterComponent({ t = defaultT, role = 'client' }: RegisterProps) {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [loading, setLoading] = useState(false)
@@ -59,12 +60,18 @@ export default function RegisterComponent({ t = defaultT }: RegisterProps) {
         data: {
           full_name: email.split('@')[0],
           locale: lang,
-          avatar_url: '/images/user/user-placeholder.png'
+          avatar_url: '/images/user/user-placeholder.png',
+          role,
         }
       }
     })
 
     if (!error && data?.user) {
+      await supabase.from('api.profiles').upsert({
+        id: data.user.id,
+        full_name: email.split('@')[0],
+        role,
+      })
       await fetch('/api/create-user-folder', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- Read role query param on registration page
- Include role in Supabase signup and profiles upsert

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af0fc88b4c8326abdf1a9bcb898477