### PR TITLE
Ensure provider role persists on sign up

### DIFF
--- a/src/app/api/create-user-folder/route.ts
+++ b/src/app/api/create-user-folder/route.ts
@@ -7,12 +7,21 @@ export const runtime = 'nodejs'
 
 export async function POST(req: Request) {
   try {
-    const { userId } = await req.json()
+    const { userId, role = 'client', fullName = '' } = await req.json()
     if (!userId) {
       return NextResponse.json({ error: 'Missing userId' }, { status: 400 })
     }
 
     const supabase = getSupabaseAdmin()
+
+    const { error: profileError } = await supabase
+      .from('profiles')
+      .upsert({ id: userId, full_name: fullName, role })
+
+    if (profileError) {
+      return NextResponse.json({ error: profileError.message }, { status: 500 })
+    }
+
     // All user uploads live in the public "users-data" bucket so
     // ensure that bucket and a folder for this user exist.
     const bucket = 'users-data'

--- a/src/app/auth/register/components/RegisterForm.tsx
+++ b/src/app/auth/register/components/RegisterForm.tsx
@@ -69,15 +69,14 @@ export default function RegisterComponent({ t = defaultT, role = 'client' }: Reg
     })
 
     if (!error && data?.user) {
-      await supabase.from('api.profiles').upsert({
-        id: data.user.id,
-        full_name: email.split('@')[0],
-        role,
-      })
       await fetch('/api/create-user-folder', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userId: data.user.id })
+        body: JSON.stringify({
+          userId: data.user.id,
+          fullName: email.split('@')[0],
+          role,
+        }),
       })
     }
 


### PR DESCRIPTION
## Summary
- forward role to server when registering and remove client-side profile upsert
- create user profile with role via admin client before provisioning storage

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af164effbc8326a25f6022288e1858