### PR TITLE
feat: add informational policy pages

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -96,7 +96,7 @@ export default function HomeClient() {
       </div>
       <div className="w-full">
         <CardSection locale={locale} t={t} />
-        <Footer t={t} />
+        <Footer t={t} locale={locale} />
       </div>
     </div>
   )

--- a/src/app/cards/accessibility-tools/AccessibilityClient.tsx
+++ b/src/app/cards/accessibility-tools/AccessibilityClient.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Navbar from '@/components/layout/Navbar'
+import { useRouter, useSearchParams } from 'next/navigation'
+
+export default function AccessibilityClient() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const langParam = searchParams.get('lang')
+
+  const [locale, setLocale] = useState<'en' | 'es'>('es')
+
+  useEffect(() => {
+    if (langParam === 'es' || langParam === 'en') {
+      setLocale(langParam)
+    } else {
+      const browserLang = navigator.language.startsWith('es') ? 'es' : 'en'
+      setLocale(browserLang)
+    }
+  }, [langParam])
+
+  const toggleLocale = () => {
+    const newLocale = locale === 'en' ? 'es' : 'en'
+    setLocale(newLocale)
+    router.push(`?lang=${newLocale}`)
+  }
+
+  const t = {
+    login: locale === 'es' ? 'Iniciar sesión' : 'Log in',
+    signup: locale === 'es' ? 'Crear cuenta' : 'Sign up',
+    searchPlaceholder: locale === 'es' ? 'Buscar servicio...' : 'Search service...',
+    language: locale === 'es' ? 'Español' : 'English',
+    joinAsPro: locale === 'es' ? 'Unirse como proveedor' : 'Join as provider',
+    howItWorks: locale === 'es' ? 'Cómo funciona Presu' : 'How Presu Works',
+  }
+
+  const content = {
+    title: locale === 'es' ? 'Herramientas de accesibilidad' : 'Accessibility Tools',
+    body:
+      locale === 'es'
+        ? 'Conocé las herramientas para mejorar la accesibilidad en Presu.'
+        : 'Learn about tools to improve accessibility on Presu.',
+  }
+
+  return (
+    <>
+      <Navbar locale={locale} toggleLocale={toggleLocale} t={t} forceWhite />
+      <main className="bg-black text-white w-full pt-32 pb-24">
+        <section className="max-w-4xl mx-auto px-6 sm:px-12">
+          <h1 className="text-3xl sm:text-5xl font-extrabold mb-6 leading-tight">{content.title}</h1>
+          <p className="text-gray-300 whitespace-pre-line">{content.body}</p>
+        </section>
+      </main>
+    </>
+  )
+}
+

--- a/src/app/cards/accessibility-tools/page.tsx
+++ b/src/app/cards/accessibility-tools/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from 'react'
+import AccessibilityClient from './AccessibilityClient'
+
+export default function AccessibilityPage() {
+  return (
+    <Suspense fallback={<div className="text-center p-8">Loading...</div>}>
+      <AccessibilityClient />
+    </Suspense>
+  )
+}

--- a/src/app/cards/privacy-policy/PrivacyClient.tsx
+++ b/src/app/cards/privacy-policy/PrivacyClient.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Navbar from '@/components/layout/Navbar'
+import { useRouter, useSearchParams } from 'next/navigation'
+
+export default function PrivacyClient() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const langParam = searchParams.get('lang')
+
+  const [locale, setLocale] = useState<'en' | 'es'>('es')
+
+  useEffect(() => {
+    if (langParam === 'es' || langParam === 'en') {
+      setLocale(langParam)
+    } else {
+      const browserLang = navigator.language.startsWith('es') ? 'es' : 'en'
+      setLocale(browserLang)
+    }
+  }, [langParam])
+
+  const toggleLocale = () => {
+    const newLocale = locale === 'en' ? 'es' : 'en'
+    setLocale(newLocale)
+    router.push(`?lang=${newLocale}`)
+  }
+
+  const t = {
+    login: locale === 'es' ? 'Iniciar sesión' : 'Log in',
+    signup: locale === 'es' ? 'Crear cuenta' : 'Sign up',
+    searchPlaceholder: locale === 'es' ? 'Buscar servicio...' : 'Search service...',
+    language: locale === 'es' ? 'Español' : 'English',
+    joinAsPro: locale === 'es' ? 'Unirse como proveedor' : 'Join as provider',
+    howItWorks: locale === 'es' ? 'Cómo funciona Presu' : 'How Presu Works',
+  }
+
+  const content = {
+    title: locale === 'es' ? 'Política de privacidad' : 'Privacy Policy',
+    body:
+      locale === 'es'
+        ? 'Valoramos tu privacidad. Esta política explica cómo manejamos tus datos.'
+        : 'We value your privacy. This policy explains how we handle your data.',
+  }
+
+  return (
+    <>
+      <Navbar locale={locale} toggleLocale={toggleLocale} t={t} forceWhite />
+      <main className="bg-black text-white w-full pt-32 pb-24">
+        <section className="max-w-4xl mx-auto px-6 sm:px-12">
+          <h1 className="text-3xl sm:text-5xl font-extrabold mb-6 leading-tight">{content.title}</h1>
+          <p className="text-gray-300 whitespace-pre-line">{content.body}</p>
+        </section>
+      </main>
+    </>
+  )
+}
+

--- a/src/app/cards/privacy-policy/page.tsx
+++ b/src/app/cards/privacy-policy/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from 'react'
+import PrivacyClient from './PrivacyClient'
+
+export default function PrivacyPage() {
+  return (
+    <Suspense fallback={<div className="text-center p-8">Loading...</div>}>
+      <PrivacyClient />
+    </Suspense>
+  )
+}

--- a/src/app/cards/sitemap/SitemapClient.tsx
+++ b/src/app/cards/sitemap/SitemapClient.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Navbar from '@/components/layout/Navbar'
+import { useRouter, useSearchParams } from 'next/navigation'
+
+export default function SitemapClient() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const langParam = searchParams.get('lang')
+
+  const [locale, setLocale] = useState<'en' | 'es'>('es')
+
+  useEffect(() => {
+    if (langParam === 'es' || langParam === 'en') {
+      setLocale(langParam)
+    } else {
+      const browserLang = navigator.language.startsWith('es') ? 'es' : 'en'
+      setLocale(browserLang)
+    }
+  }, [langParam])
+
+  const toggleLocale = () => {
+    const newLocale = locale === 'en' ? 'es' : 'en'
+    setLocale(newLocale)
+    router.push(`?lang=${newLocale}`)
+  }
+
+  const t = {
+    login: locale === 'es' ? 'Iniciar sesión' : 'Log in',
+    signup: locale === 'es' ? 'Crear cuenta' : 'Sign up',
+    searchPlaceholder: locale === 'es' ? 'Buscar servicio...' : 'Search service...',
+    language: locale === 'es' ? 'Español' : 'English',
+    joinAsPro: locale === 'es' ? 'Unirse como proveedor' : 'Join as provider',
+    howItWorks: locale === 'es' ? 'Cómo funciona Presu' : 'How Presu Works',
+  }
+
+  const content = {
+    title: locale === 'es' ? 'Mapa del sitio' : 'Sitemap',
+    body:
+      locale === 'es'
+        ? 'Explorá todas las secciones de nuestro sitio.'
+        : 'Browse all sections of our site.',
+  }
+
+  return (
+    <>
+      <Navbar locale={locale} toggleLocale={toggleLocale} t={t} forceWhite />
+      <main className="bg-black text-white w-full pt-32 pb-24">
+        <section className="max-w-4xl mx-auto px-6 sm:px-12">
+          <h1 className="text-3xl sm:text-5xl font-extrabold mb-6 leading-tight">{content.title}</h1>
+          <p className="text-gray-300 whitespace-pre-line">{content.body}</p>
+        </section>
+      </main>
+    </>
+  )
+}
+

--- a/src/app/cards/sitemap/page.tsx
+++ b/src/app/cards/sitemap/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from 'react'
+import SitemapClient from './SitemapClient'
+
+export default function SitemapPage() {
+  return (
+    <Suspense fallback={<div className="text-center p-8">Loading...</div>}>
+      <SitemapClient />
+    </Suspense>
+  )
+}

--- a/src/app/cards/terms-of-use/TermsClient.tsx
+++ b/src/app/cards/terms-of-use/TermsClient.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Navbar from '@/components/layout/Navbar'
+import { useRouter, useSearchParams } from 'next/navigation'
+
+export default function TermsClient() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const langParam = searchParams.get('lang')
+
+  const [locale, setLocale] = useState<'en' | 'es'>('es')
+
+  useEffect(() => {
+    if (langParam === 'es' || langParam === 'en') {
+      setLocale(langParam)
+    } else {
+      const browserLang = navigator.language.startsWith('es') ? 'es' : 'en'
+      setLocale(browserLang)
+    }
+  }, [langParam])
+
+  const toggleLocale = () => {
+    const newLocale = locale === 'en' ? 'es' : 'en'
+    setLocale(newLocale)
+    router.push(`?lang=${newLocale}`)
+  }
+
+  const t = {
+    login: locale === 'es' ? 'Iniciar sesión' : 'Log in',
+    signup: locale === 'es' ? 'Crear cuenta' : 'Sign up',
+    searchPlaceholder: locale === 'es' ? 'Buscar servicio...' : 'Search service...',
+    language: locale === 'es' ? 'Español' : 'English',
+    joinAsPro: locale === 'es' ? 'Unirse como proveedor' : 'Join as provider',
+    howItWorks: locale === 'es' ? 'Cómo funciona Presu' : 'How Presu Works',
+  }
+
+  const content = {
+    title: locale === 'es' ? 'Términos de uso' : 'Terms of Use',
+    body:
+      locale === 'es'
+        ? 'Estos términos rigen tu uso de Presu.'
+        : 'These terms govern your use of Presu.',
+  }
+
+  return (
+    <>
+      <Navbar locale={locale} toggleLocale={toggleLocale} t={t} forceWhite />
+      <main className="bg-black text-white w-full pt-32 pb-24">
+        <section className="max-w-4xl mx-auto px-6 sm:px-12">
+          <h1 className="text-3xl sm:text-5xl font-extrabold mb-6 leading-tight">{content.title}</h1>
+          <p className="text-gray-300 whitespace-pre-line">{content.body}</p>
+        </section>
+      </main>
+    </>
+  )
+}
+

--- a/src/app/cards/terms-of-use/page.tsx
+++ b/src/app/cards/terms-of-use/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from 'react'
+import TermsClient from './TermsClient'
+
+export default function TermsPage() {
+  return (
+    <Suspense fallback={<div className="text-center p-8">Loading...</div>}>
+      <TermsClient />
+    </Suspense>
+  )
+}

--- a/src/app/services/[service]/ServiceFormClient.tsx
+++ b/src/app/services/[service]/ServiceFormClient.tsx
@@ -632,7 +632,7 @@ export default function ServiceFormClient({ service }: Props) {
         </div>
         </div>
       </main>
-      <Footer t={footerT} />
+      <Footer t={footerT} locale={locale} />
       {submitted && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
           <div className="bg-white dark:bg-gray-800 p-6 rounded-lg text-center shadow-lg">

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image'
+import Link from 'next/link'
 
 type FooterProps = {
   t: {
@@ -9,9 +10,10 @@ type FooterProps = {
     footerNote: string
     copyright: string
   }
+  locale: 'en' | 'es'
 }
 
-export default function Footer({ t }: FooterProps) {
+export default function Footer({ t, locale }: FooterProps) {
   return (
     <footer className="bg-gray-50 border-t text-gray-600 text-sm px-6 py-10">
       <div className="max-w-3xl mx-auto flex flex-col items-center text-center gap-4">
@@ -31,13 +33,29 @@ export default function Footer({ t }: FooterProps) {
 
         {/* Legal links */}
         <ul className="flex flex-wrap justify-center items-center gap-3 text-xs text-gray-600">
-          <li><a href="#" className="hover:underline">{t.terms}</a></li>
+          <li>
+            <Link href={`/cards/terms-of-use?lang=${locale}`} className="hover:underline">
+              {t.terms}
+            </Link>
+          </li>
           <li>|</li>
-          <li><a href="#" className="hover:underline">{t.privacy}</a></li>
+          <li>
+            <Link href={`/cards/privacy-policy?lang=${locale}`} className="hover:underline">
+              {t.privacy}
+            </Link>
+          </li>
           <li>|</li>
-          <li><a href="#" className="hover:underline">{t.sitemap}</a></li>
+          <li>
+            <Link href={`/cards/sitemap?lang=${locale}`} className="hover:underline">
+              {t.sitemap}
+            </Link>
+          </li>
           <li>|</li>
-          <li><a href="#" className="hover:underline">{t.accessibility}</a></li>
+          <li>
+            <Link href={`/cards/accessibility-tools?lang=${locale}`} className="hover:underline">
+              {t.accessibility}
+            </Link>
+          </li>
         </ul>
 
         {/* Social Icons */}


### PR DESCRIPTION
## Summary
- add terms of use, privacy policy, sitemap, and accessibility tools pages modeled after join-us layout
- enable locale toggling and navbar on each new page

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af1cb678708326a74d3e6f4d7209b6