### PR TITLE
Add help page and enhance sitemap

### DIFF
--- a/src/app/cards/sitemap/SitemapClient.tsx
+++ b/src/app/cards/sitemap/SitemapClient.tsx
@@ -2,20 +2,18 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import Navbar from '@/components/layout/Navbar'
+import Link from 'next/link'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
-import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
 
 const SUPPORTED_LOCALES = ['en', 'es'] as const
-type Locale = (typeof SUPPORTED_LOCALES)[number]
-const isLocale = (v: string | null): v is Locale => v === 'en' || v === 'es'
+ type Locale = (typeof SUPPORTED_LOCALES)[number]
+ const isLocale = (v: string | null): v is Locale => v === 'en' || v === 'es'
 
 export default function SitemapClient() {
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
 
-  // Resolve initial locale (URL param > browser)
   const initialLocale: Locale = useMemo(() => {
     const param = searchParams.get('lang')
     if (isLocale(param)) return param
@@ -27,27 +25,24 @@ export default function SitemapClient() {
 
   const [locale, setLocale] = useState<Locale>(initialLocale)
 
-  // Sync locale if user navigates and lang changes
   useEffect(() => {
     const param = searchParams.get('lang')
     if (isLocale(param) && param !== locale) setLocale(param)
   }, [searchParams, locale])
 
-  // URL helper to keep other params
   const pushWithLang = (newLocale: Locale) => {
     const params = new URLSearchParams(searchParams.toString())
     params.set('lang', newLocale)
     router.push(`${pathname}?${params.toString()}`)
   }
 
-  // Exposed for Navbar if it toggles language
   const toggleLocale = () => {
     const next: Locale = locale === 'en' ? 'es' : 'en'
     setLocale(next)
     pushWithLang(next)
   }
 
-  const t = useMemo(
+  const navT = useMemo(
     () => ({
       login: locale === 'es' ? 'Iniciar sesión' : 'Log in',
       signup: locale === 'es' ? 'Crear cuenta' : 'Sign up',
@@ -66,72 +61,87 @@ export default function SitemapClient() {
       return {
         title: 'Mapa del sitio',
         lastUpdated: 'Actualizado el 27 de agosto de 2025',
-        md: `> **Presu** – Navegación principal del sitio
-
----
-
-### Secciones principales
-- **[Inicio](/)** – Introducción a nuestros servicios.  
-- **[Market Comparison](/cards/market-comparison)** – Potenciá tus compras.  
-- **[Join Us](/cards/join-us)** – Unite a Presu y conectá con nuevos clientes.  
-- **[Sustainability](/cards/sustainability)** – Comprometidos con la sostenibilidad.  
-- **[Servicios](/services)** – Soluciones disponibles.  
-- **[Contacto](/contact)** – Escribinos para consultas.
-
-### Cuenta
-- **[Iniciar sesión](/auth/login)**  
-- **[Crear cuenta](/auth//register)**
-
-### Legal
-- **[Términos de uso](/cards/terms-of-use)**  
-- **[Política de privacidad](/cards/privacy-policy)**  
-- **[Herramientas de accesibilidad](/cards/accessibility-tools)**
-
----
-
-> ¿No encontraste lo que buscabas? Probá la barra de búsqueda o escribinos a **info@presu.com.ar**.`,
+        sections: [
+          {
+            title: 'Secciones principales',
+            links: [
+              { href: '/', label: 'Inicio', description: 'Introducción a nuestros servicios.' },
+              { href: '/cards/market-comparison', label: 'Market Comparison', description: 'Potenciá tus compras.' },
+              { href: '/cards/join-us', label: 'Join Us', description: 'Unite a Presu y conectá con nuevos clientes.' },
+              { href: '/cards/sustainability', label: 'Sustainability', description: 'Comprometidos con la sostenibilidad.' },
+              { href: '/services', label: 'Servicios', description: 'Soluciones disponibles.' },
+              { href: '/help#contact', label: 'Ayuda y Contacto', description: 'Escribinos para consultas.' },
+            ],
+          },
+          {
+            title: 'Cuenta',
+            links: [
+              { href: '/auth/login', label: 'Iniciar sesión' },
+              { href: '/auth/register', label: 'Crear cuenta' },
+              { href: '/dashboard', label: 'Panel' },
+              { href: '/activity', label: 'Actividad' },
+              { href: '/settings', label: 'Configuración' },
+            ],
+          },
+          {
+            title: 'Legal',
+            links: [
+              { href: '/cards/terms-of-use', label: 'Términos de uso' },
+              { href: '/cards/privacy-policy', label: 'Política de privacidad' },
+              { href: '/cards/accessibility-tools', label: 'Herramientas de accesibilidad' },
+            ],
+          },
+        ],
+        note: '¿No encontraste lo que buscabas? Probá la barra de búsqueda o escribinos a ',
       }
     }
     return {
       title: 'Sitemap',
       lastUpdated: 'Last updated August 27, 2025',
-      md: `> **Presu** – Main site navigation
-
----
-
-### Core Sections
-- **[Home](/)** – Overview of our services.  
-- **[Market Comparison](/cards/market-comparison)** – Boost your purchasing.  
-- **[Join Us](/cards/join-us)** – Join Presu and connect with new clients.  
-- **[Sustainability](/cards/sustainability)** – Committed to Sustainability.  
-- **[Services](/services)** – Available solutions.  
-- **[Contact](/contact)** – Get in touch.
-
-### Account
-- **[Log in](/auth/login)**  
-- **[Sign up](/auth/register)**
-
-### Legal
-- **[Terms of Use](/cards/terms-of-use)**  
-- **[Privacy Policy](/cards/privacy-policy)**  
-- **[Accessibility Tools](/cards/accessibility-tools)**
-
----
-
-> Can't find something? Try search or email **info@presu.com.ar**.`,
+      sections: [
+        {
+          title: 'Core Sections',
+          links: [
+            { href: '/', label: 'Home', description: 'Overview of our services.' },
+            { href: '/cards/market-comparison', label: 'Market Comparison', description: 'Boost your purchasing.' },
+            { href: '/cards/join-us', label: 'Join Us', description: 'Join Presu and connect with new clients.' },
+            { href: '/cards/sustainability', label: 'Sustainability', description: 'Committed to Sustainability.' },
+            { href: '/services', label: 'Services', description: 'Available solutions.' },
+            { href: '/help#contact', label: 'Help & Contact', description: 'Get assistance or contact us.' },
+          ],
+        },
+        {
+          title: 'Account',
+          links: [
+            { href: '/auth/login', label: 'Log in' },
+            { href: '/auth/register', label: 'Sign up' },
+            { href: '/dashboard', label: 'Dashboard' },
+            { href: '/activity', label: 'Activity' },
+            { href: '/settings', label: 'Settings' },
+          ],
+        },
+        {
+          title: 'Legal',
+          links: [
+            { href: '/cards/terms-of-use', label: 'Terms of Use' },
+            { href: '/cards/privacy-policy', label: 'Privacy Policy' },
+            { href: '/cards/accessibility-tools', label: 'Accessibility Tools' },
+          ],
+        },
+      ],
+      note: "Can't find something? Try search or email ",
     }
   }, [locale])
 
   return (
     <>
-      <Navbar locale={locale} toggleLocale={toggleLocale} t={t} forceWhite />
+      <Navbar locale={locale} toggleLocale={toggleLocale} t={navT} forceWhite />
       <main className="min-h-screen w-full bg-gradient-to-b from-neutral-950 via-black to-neutral-950 text-white pt-28 pb-24">
-        {/* Breadcrumb */}
         <nav className="mx-auto mb-6 max-w-5xl px-6 sm:px-10 text-sm text-gray-400">
           <ol className="flex items-center gap-2">
             <li>
               <a href="/" className="hover:text-gray-200 transition-colors">
-                {t.home}
+                {navT.home}
               </a>
             </li>
             <li aria-hidden="true">/</li>
@@ -142,13 +152,10 @@ export default function SitemapClient() {
         </nav>
 
         <section className="mx-auto max-w-5xl px-6 sm:px-10">
-          {/* Header Card */}
           <header className="mb-8 rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur">
             <div className="flex flex-wrap items-center justify-between gap-4">
               <div>
-                <h1 className="text-3xl sm:text-5xl font-extrabold tracking-tight">
-                  {content.title}
-                </h1>
+                <h1 className="text-3xl sm:text-5xl font-extrabold tracking-tight">{content.title}</h1>
                 <p className="mt-2 inline-flex items-center gap-2 text-sm text-gray-300">
                   <span className="inline-flex items-center rounded-full border border-emerald-400/30 bg-emerald-400/10 px-2.5 py-0.5">
                     <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 mr-2" />
@@ -159,36 +166,39 @@ export default function SitemapClient() {
             </div>
           </header>
 
-          {/* Markdown Body */}
-          <article className="prose prose-invert max-w-none">
-            <ReactMarkdown
-              remarkPlugins={[remarkGfm]}
-              components={{
-                h2: ({ node, ...props }) => (
-                  <h2 className="mt-8 text-2xl font-bold tracking-tight" {...props} />
-                ),
-                h3: ({ node, ...props }) => (
-                  <h3 className="mt-6 text-xl font-semibold tracking-tight" {...props} />
-                ),
-                p: ({ node, ...props }) => (
-                  <p className="leading-relaxed text-gray-200" {...props} />
-                ),
-                ul: ({ node, ...props }) => <ul className="list-disc pl-6" {...props} />,
-                ol: ({ node, ...props }) => <ol className="list-decimal pl-6" {...props} />,
-                li: ({ node, ...props }) => <li className="my-1" {...props} />,
-                a: ({ node, ...props }) => (
-                  <a className="underline decoration-emerald-400/50 underline-offset-4 hover:decoration-emerald-300" {...props} />
-                ),
-                hr: () => <hr className="my-8 border-white/10" />,
-                blockquote: ({ node, ...props }) => (
-                  <blockquote className="border-l-4 border-emerald-400/50 pl-4 text-gray-200/90" {...props} />
-                ),
-                strong: ({ node, ...props }) => <strong className="text-white" {...props} />,
-              }}
+          <div className="grid gap-8 sm:grid-cols-2">
+            {content.sections.map((section) => (
+              <div key={section.title} className="rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+                <h2 className="text-xl font-bold mb-4">{section.title}</h2>
+                <ul className="space-y-2">
+                  {section.links.map((link) => (
+                    <li key={link.href}>
+                      <Link
+                        href={link.href}
+                        className="underline decoration-emerald-400/50 underline-offset-4 hover:decoration-emerald-300"
+                      >
+                        {link.label}
+                      </Link>
+                      {link.description && (
+                        <p className="text-sm text-gray-300">{link.description}</p>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+
+          <p className="mt-8 text-sm text-gray-400">
+            {content.note}
+            <a
+              href="mailto:info@presu.com.ar"
+              className="underline decoration-emerald-400/50 underline-offset-4 hover:decoration-emerald-300"
             >
-              {content.md}
-            </ReactMarkdown>
-          </article>
+              info@presu.com.ar
+            </a>
+            .
+          </p>
         </section>
       </main>
     </>

--- a/src/app/help/HelpClient.tsx
+++ b/src/app/help/HelpClient.tsx
@@ -1,0 +1,116 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import Navbar from '@/components/layout/Navbar'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+
+const SUPPORTED_LOCALES = ['en', 'es'] as const
+ type Locale = (typeof SUPPORTED_LOCALES)[number]
+ const isLocale = (v: string | null): v is Locale => v === 'en' || v === 'es'
+
+export default function HelpClient() {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const initialLocale: Locale = useMemo(() => {
+    const param = searchParams.get('lang')
+    if (isLocale(param)) return param
+    if (typeof navigator !== 'undefined') {
+      return navigator.language?.toLowerCase().startsWith('es') ? 'es' : 'en'
+    }
+    return 'en'
+  }, [searchParams])
+
+  const [locale, setLocale] = useState<Locale>(initialLocale)
+
+  useEffect(() => {
+    const param = searchParams.get('lang')
+    if (isLocale(param) && param !== locale) setLocale(param)
+  }, [searchParams, locale])
+
+  const pushWithLang = (newLocale: Locale) => {
+    const params = new URLSearchParams(searchParams.toString())
+    params.set('lang', newLocale)
+    router.push(`${pathname}?${params.toString()}`)
+  }
+
+  const toggleLocale = () => {
+    const next: Locale = locale === 'en' ? 'es' : 'en'
+    setLocale(next)
+    pushWithLang(next)
+  }
+
+  const navT = useMemo(
+    () => ({
+      login: locale === 'es' ? 'Iniciar sesión' : 'Log in',
+      signup: locale === 'es' ? 'Crear cuenta' : 'Sign up',
+      searchPlaceholder: locale === 'es' ? 'Buscar servicio...' : 'Search service...',
+      language: locale === 'es' ? 'Español' : 'English',
+      joinAsPro: locale === 'es' ? 'Unirse como proveedor' : 'Join as provider',
+      howItWorks: locale === 'es' ? 'Cómo funciona Presu' : 'How Presu Works',
+      home: locale === 'es' ? 'Inicio' : 'Home',
+      legal: locale === 'es' ? 'Legal' : 'Legal',
+    }),
+    [locale]
+  )
+
+  const content = useMemo(
+    () =>
+      locale === 'es'
+        ? {
+            title: 'Ayuda y Contacto',
+            intro: 'Encontrá respuestas o escribinos.',
+            contactHeading: 'Contacto',
+            contactDescription: 'Envíanos un correo a',
+          }
+        : {
+            title: 'Help & Contact',
+            intro: 'Find answers or reach out to us.',
+            contactHeading: 'Contact',
+            contactDescription: 'Send us an email at',
+          },
+    [locale]
+  )
+
+  return (
+    <>
+      <Navbar locale={locale} toggleLocale={toggleLocale} t={navT} forceWhite />
+      <main className="min-h-screen w-full bg-gradient-to-b from-neutral-950 via-black to-neutral-950 text-white pt-28 pb-24">
+        <nav className="mx-auto mb-6 max-w-5xl px-6 sm:px-10 text-sm text-gray-400">
+          <ol className="flex items-center gap-2">
+            <li>
+              <a href="/" className="hover:text-gray-200 transition-colors">
+                {navT.home}
+              </a>
+            </li>
+            <li aria-hidden="true">/</li>
+            <li>
+              <span className="text-gray-100">{content.title}</span>
+            </li>
+          </ol>
+        </nav>
+
+        <section className="mx-auto max-w-5xl px-6 sm:px-10">
+          <header className="mb-8 rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+            <h1 className="text-3xl sm:text-5xl font-extrabold tracking-tight">{content.title}</h1>
+            <p className="mt-2 text-sm text-gray-300">{content.intro}</p>
+          </header>
+
+          <div id="contact" className="rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+            <h2 className="text-2xl font-bold mb-4">{content.contactHeading}</h2>
+            <p className="text-gray-300">
+              {content.contactDescription}{' '}
+              <a
+                href="mailto:info@presu.com.ar"
+                className="underline decoration-emerald-400/50 underline-offset-4 hover:decoration-emerald-300"
+              >
+                info@presu.com.ar
+              </a>
+            </p>
+          </div>
+        </section>
+      </main>
+    </>
+  )
+}

--- a/src/app/help/page.tsx
+++ b/src/app/help/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from 'react'
+import HelpClient from './HelpClient'
+
+export default function HelpPage() {
+  return (
+    <Suspense fallback={<div className="text-center p-8">Loading...</div>}>
+      <HelpClient />
+    </Suspense>
+  )
+}

--- a/src/components/layout/UserMenu.tsx
+++ b/src/components/layout/UserMenu.tsx
@@ -167,10 +167,14 @@ export default function UserMenu({ user, locale }: Props) {
                         <Image src="/images/user/user-activity.png" alt={activityAlt} width={28} height={28} />
                         <span className="text-sm mt-1 font-semibold">{activityText}</span>
                     </Link>
-                    <button className="flex flex-col items-center justify-center p-4 rounded-xl bg-gray-100 hover:bg-gray-200 transition transform hover:scale-105">
+                    <Link
+                        href="/help"
+                        onClick={() => setOpen(false)}
+                        className="flex flex-col items-center justify-center p-4 rounded-xl bg-gray-100 hover:bg-gray-200 transition transform hover:scale-105"
+                    >
                         <Image src="/images/user/user-help.png" alt={helpAlt} width={28} height={28} />
                         <span className="text-sm mt-1 font-semibold">{helpText}</span>
-                    </button>
+                    </Link>
                 </div>
 
                 {/* Settings - Centered */}


### PR DESCRIPTION
## Summary
- Add new Help & Contact page with localized content
- Link Help from user menu and update sitemap to include Help & Contact plus account pages
- Redesign sitemap into grid layout for clearer navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: multiple lint errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68af2cf17b8c8326b502655154977cf8