### PR TITLE
feat: enhance help and contact page

### DIFF
--- a/src/app/help/HelpClient.tsx
+++ b/src/app/help/HelpClient.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useMemo, useState } from 'react'
 import Navbar from '@/components/layout/Navbar'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import Script from 'next/script'
+import { NAV_DICT, HELP_DICT, HelpLocale } from './dictionaries'
 
 const SUPPORTED_LOCALES = ['en', 'es'] as const
  type Locale = (typeof SUPPORTED_LOCALES)[number]
@@ -29,84 +31,122 @@ export default function HelpClient() {
     if (isLocale(param) && param !== locale) setLocale(param)
   }, [searchParams, locale])
 
-  const pushWithLang = (newLocale: Locale) => {
+  const replaceWithLang = (newLocale: Locale) => {
     const params = new URLSearchParams(searchParams.toString())
     params.set('lang', newLocale)
-    router.push(`${pathname}?${params.toString()}`)
+    router.replace(`${pathname}?${params.toString()}`)
   }
 
   const toggleLocale = () => {
     const next: Locale = locale === 'en' ? 'es' : 'en'
     setLocale(next)
-    pushWithLang(next)
+    replaceWithLang(next)
   }
 
-  const navT = useMemo(
-    () => ({
-      login: locale === 'es' ? 'Iniciar sesión' : 'Log in',
-      signup: locale === 'es' ? 'Crear cuenta' : 'Sign up',
-      searchPlaceholder: locale === 'es' ? 'Buscar servicio...' : 'Search service...',
-      language: locale === 'es' ? 'Español' : 'English',
-      joinAsPro: locale === 'es' ? 'Unirse como proveedor' : 'Join as provider',
-      howItWorks: locale === 'es' ? 'Cómo funciona Presu' : 'How Presu Works',
-      home: locale === 'es' ? 'Inicio' : 'Home',
-      legal: locale === 'es' ? 'Legal' : 'Legal',
-    }),
-    [locale]
-  )
-
-  const content = useMemo(
-    () =>
-      locale === 'es'
-        ? {
-            title: 'Ayuda y Contacto',
-            intro: 'Encontrá respuestas o escribinos.',
-            contactHeading: 'Contacto',
-            contactDescription: 'Envíanos un correo a',
-          }
-        : {
-            title: 'Help & Contact',
-            intro: 'Find answers or reach out to us.',
-            contactHeading: 'Contact',
-            contactDescription: 'Send us an email at',
-          },
+  const navT = NAV_DICT[locale]
+  const t = HELP_DICT[locale as HelpLocale]
+  const lastUpdated = useMemo(
+    () => new Intl.DateTimeFormat(locale, { dateStyle: 'long' }).format(new Date()),
     [locale]
   )
 
   return (
     <>
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only absolute left-2 top-2 z-50 rounded bg-black px-3 py-2 text-white"
+      >
+        {t.skip}
+      </a>
       <Navbar locale={locale} toggleLocale={toggleLocale} t={navT} forceWhite />
-      <main className="min-h-screen w-full bg-gradient-to-b from-neutral-950 via-black to-neutral-950 text-white pt-28 pb-24">
-        <nav className="mx-auto mb-6 max-w-5xl px-6 sm:px-10 text-sm text-gray-400">
+      <Script
+        id="contact-jsonld"
+        type="application/ld+json"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'ContactPage',
+            url: 'https://presu.com.ar/help',
+            mainEntity: {
+              '@type': 'Organization',
+              name: 'Presu',
+              contactPoint: {
+                '@type': 'ContactPoint',
+                email: 'info@presu.com.ar',
+                contactType: 'customer support',
+                availableLanguage: ['English', 'Spanish'],
+              },
+            },
+          }),
+        }}
+      />
+      <main
+        id="main-content"
+        className="min-h-screen w-full bg-gradient-to-b from-neutral-950 via-black to-neutral-950 pt-28 pb-24 text-white"
+      >
+        <nav
+          className="mx-auto mb-6 max-w-5xl px-6 text-sm text-gray-400 sm:px-10"
+          aria-label={t.breadcrumbLabel}
+        >
           <ol className="flex items-center gap-2">
             <li>
-              <a href="/" className="hover:text-gray-200 transition-colors">
+              <a href="/" className="transition-colors hover:text-gray-200">
                 {navT.home}
               </a>
             </li>
             <li aria-hidden="true">/</li>
             <li>
-              <span className="text-gray-100">{content.title}</span>
+              <span className="text-gray-100">{t.title}</span>
             </li>
           </ol>
         </nav>
 
         <section className="mx-auto max-w-5xl px-6 sm:px-10">
           <header className="mb-8 rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur">
-            <h1 className="text-3xl sm:text-5xl font-extrabold tracking-tight">{content.title}</h1>
-            <p className="mt-2 text-sm text-gray-300">{content.intro}</p>
+            <h1 className="text-3xl font-extrabold tracking-tight sm:text-5xl">{t.title}</h1>
+            <p className="mt-2 text-sm text-gray-300">{t.intro}</p>
           </header>
 
-          <div id="contact" className="rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur">
-            <h2 className="text-2xl font-bold mb-4">{content.contactHeading}</h2>
+          <div
+            id="contact"
+            className="mb-8 rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur"
+          >
+            <h2 className="mb-4 text-2xl font-bold">{t.contactHeading}</h2>
             <p className="text-gray-300">
-              {content.contactDescription}{' '}
+              {t.contactDescription}{' '}
               <a
-                href="mailto:info@presu.com.ar"
+                href={`mailto:info@presu.com.ar?subject=${encodeURIComponent(t.contactMailSubject)}`}
                 className="underline decoration-emerald-400/50 underline-offset-4 hover:decoration-emerald-300"
               >
                 info@presu.com.ar
               </a>
+            </p>
+          </div>
+
+          <div className="mb-8 rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+            <h2 className="mb-4 text-2xl font-bold">{t.faqHeading}</h2>
+            {t.faqs.map((faq, idx) => (
+              <details key={idx} className="mb-4">
+                <summary className="cursor-pointer font-medium">{faq.question}</summary>
+                <p className="mt-2 text-gray-300">{faq.answer}</p>
+              </details>
+            ))}
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+            <h2 className="mb-4 text-2xl font-bold">{t.quickLinksHeading}</h2>
+            <ul className="space-y-2">
+              {t.quickLinks.map((link) => (
+                <li key={link.href}>
+                  <a href={link.href} className="text-emerald-400 hover:underline">
+                    {link.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+            <p className="mt-4 text-sm text-gray-400">
+              {t.lastUpdatedLabel}: {lastUpdated}
             </p>
           </div>
         </section>

--- a/src/app/help/dictionaries.ts
+++ b/src/app/help/dictionaries.ts
@@ -1,0 +1,81 @@
+export const NAV_DICT = {
+  en: {
+    login: 'Log in',
+    signup: 'Sign up',
+    searchPlaceholder: 'Search service...',
+    language: 'English',
+    joinAsPro: 'Join as provider',
+    howItWorks: 'How Presu Works',
+    home: 'Home',
+    legal: 'Legal',
+  },
+  es: {
+    login: 'Iniciar sesión',
+    signup: 'Crear cuenta',
+    searchPlaceholder: 'Buscar servicio...',
+    language: 'Español',
+    joinAsPro: 'Unirse como proveedor',
+    howItWorks: 'Cómo funciona Presu',
+    home: 'Inicio',
+    legal: 'Legal',
+  },
+} as const
+
+export const HELP_DICT = {
+  en: {
+    skip: 'Skip to main content',
+    title: 'Help & Contact',
+    intro: 'Find answers or reach out to us.',
+    breadcrumbLabel: 'Breadcrumb',
+    contactHeading: 'Contact',
+    contactDescription: 'Send us an email at',
+    contactMailSubject: 'Presu support',
+    faqHeading: 'Frequently Asked Questions',
+    faqs: [
+      {
+        question: 'How do I become a provider?',
+        answer: 'Sign up and complete your profile to join as a provider.',
+      },
+      {
+        question: 'Where can I view my activity?',
+        answer: 'Navigate to your dashboard and select the activity tab.',
+      },
+    ],
+    quickLinksHeading: 'Quick Links',
+    quickLinks: [
+      { href: '/cards/terms-of-use', label: 'Terms of Use' },
+      { href: '/cards/privacy-policy', label: 'Privacy Policy' },
+      { href: '/cards/accessibility-tools', label: 'Accessibility Tools' },
+    ],
+    lastUpdatedLabel: 'Last updated',
+  },
+  es: {
+    skip: 'Saltar al contenido principal',
+    title: 'Ayuda y Contacto',
+    intro: 'Encontrá respuestas o escribinos.',
+    breadcrumbLabel: 'Ruta de navegación',
+    contactHeading: 'Contacto',
+    contactDescription: 'Envíanos un correo a',
+    contactMailSubject: 'Soporte Presu',
+    faqHeading: 'Preguntas frecuentes',
+    faqs: [
+      {
+        question: '¿Cómo me hago proveedor?',
+        answer: 'Registrate y completá tu perfil para unirte como proveedor.',
+      },
+      {
+        question: '¿Dónde puedo ver mi actividad?',
+        answer: 'Ingresá a tu panel y seleccioná la pestaña de actividad.',
+      },
+    ],
+    quickLinksHeading: 'Enlaces rápidos',
+    quickLinks: [
+      { href: '/cards/terms-of-use', label: 'Términos de uso' },
+      { href: '/cards/privacy-policy', label: 'Política de privacidad' },
+      { href: '/cards/accessibility-tools', label: 'Herramientas de accesibilidad' },
+    ],
+    lastUpdatedLabel: 'Última actualización',
+  },
+} as const
+
+export type HelpLocale = keyof typeof HELP_DICT

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -99,7 +99,14 @@ export default function Navbar({ locale, toggleLocale, t, forceWhite = false }: 
           {/* Right: Language switch + Auth */}
           <div className="hidden md:flex items-center text-sm pr-14 gap-5 relative">
             <button
+              type="button"
               onClick={toggleLocale}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  toggleLocale()
+                }
+              }}
               className={`flex items-center gap-1 transition-colors ${isLightText ? 'text-black hover:text-gray-700' : 'text-white hover:text-gray-300'
                 }`}
               aria-label="Toggle Language"


### PR DESCRIPTION
## Summary
- centralize Help & Contact i18n dictionaries
- add accessible skip link, FAQ and quick links with last updated timestamp
- improve language toggle accessibility and SEO via JSON-LD

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af37c33078832690b4b07a3a6ba15c