### PR TITLE
style: enhance help page styling

### DIFF
--- a/src/app/help/HelpClient.tsx
+++ b/src/app/help/HelpClient.tsx
@@ -2,13 +2,14 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import Navbar from '@/components/layout/Navbar'
+import Footer from '@/components/layout/Footer'
+import Link from 'next/link'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import Script from 'next/script'
 import { NAV_DICT, HELP_DICT, HelpLocale } from './dictionaries'
 
-const SUPPORTED_LOCALES = ['en', 'es'] as const
- type Locale = (typeof SUPPORTED_LOCALES)[number]
- const isLocale = (v: string | null): v is Locale => v === 'en' || v === 'es'
+type Locale = 'en' | 'es'
+const isLocale = (v: string | null): v is Locale => v === 'en' || v === 'es'
 
 export default function HelpClient() {
   const router = useRouter()
@@ -50,6 +51,21 @@ export default function HelpClient() {
     [locale]
   )
 
+  const footerT = {
+    terms: locale === 'es' ? 'Términos de uso' : 'Terms of Use',
+    privacy: locale === 'es' ? 'Política de privacidad' : 'Privacy Policy',
+    sitemap: locale === 'es' ? 'Mapa del sitio' : 'Sitemap',
+    accessibility: locale === 'es' ? 'Accesibilidad' : 'Accessibility',
+    footerNote:
+      locale === 'es'
+        ? 'No vender ni compartir mi información personal'
+        : 'Do Not Sell or Share My Personal Information',
+    copyright:
+      locale === 'es'
+        ? 'Todos los derechos reservados.'
+        : 'All rights reserved.',
+  }
+
   return (
     <>
       <a
@@ -58,99 +74,99 @@ export default function HelpClient() {
       >
         {t.skip}
       </a>
-      <Navbar locale={locale} toggleLocale={toggleLocale} t={navT} forceWhite />
-      <Script
-        id="contact-jsonld"
-        type="application/ld+json"
-        strategy="afterInteractive"
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify({
-            '@context': 'https://schema.org',
-            '@type': 'ContactPage',
-            url: 'https://presu.com.ar/help',
-            mainEntity: {
-              '@type': 'Organization',
-              name: 'Presu',
-              contactPoint: {
-                '@type': 'ContactPoint',
-                email: 'info@presu.com.ar',
-                contactType: 'customer support',
-                availableLanguage: ['English', 'Spanish'],
+      <div className="flex min-h-screen flex-col bg-gradient-to-b from-neutral-950 via-black to-neutral-950 text-white">
+        <Navbar locale={locale} toggleLocale={toggleLocale} t={navT} forceWhite />
+        <Script
+          id="contact-jsonld"
+          type="application/ld+json"
+          strategy="afterInteractive"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'ContactPage',
+              url: 'https://presu.com.ar/help',
+              mainEntity: {
+                '@type': 'Organization',
+                name: 'Presu',
+                contactPoint: {
+                  '@type': 'ContactPoint',
+                  email: 'info@presu.com.ar',
+                  contactType: 'customer support',
+                  availableLanguage: ['English', 'Spanish'],
+                },
               },
-            },
-          }),
-        }}
-      />
-      <main
-        id="main-content"
-        className="min-h-screen w-full bg-gradient-to-b from-neutral-950 via-black to-neutral-950 pt-28 pb-24 text-white"
-      >
-        <nav
-          className="mx-auto mb-6 max-w-5xl px-6 text-sm text-gray-400 sm:px-10"
-          aria-label={t.breadcrumbLabel}
-        >
-          <ol className="flex items-center gap-2">
-            <li>
-              <a href="/" className="transition-colors hover:text-gray-200">
-                {navT.home}
-              </a>
-            </li>
-            <li aria-hidden="true">/</li>
-            <li>
-              <span className="text-gray-100">{t.title}</span>
-            </li>
-          </ol>
-        </nav>
-
-        <section className="mx-auto max-w-5xl px-6 sm:px-10">
-          <header className="mb-8 rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur">
-            <h1 className="text-3xl font-extrabold tracking-tight sm:text-5xl">{t.title}</h1>
-            <p className="mt-2 text-sm text-gray-300">{t.intro}</p>
-          </header>
-
-          <div
-            id="contact"
-            className="mb-8 rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur"
+            }),
+          }}
+        />
+        <main id="main-content" className="flex-grow pt-28 pb-24">
+          <nav
+            className="mx-auto mb-6 max-w-5xl px-6 text-sm text-gray-400 sm:px-10"
+            aria-label={t.breadcrumbLabel}
           >
-            <h2 className="mb-4 text-2xl font-bold">{t.contactHeading}</h2>
-            <p className="text-gray-300">
-              {t.contactDescription}{' '}
-              <a
-                href={`mailto:info@presu.com.ar?subject=${encodeURIComponent(t.contactMailSubject)}`}
-                className="underline decoration-emerald-400/50 underline-offset-4 hover:decoration-emerald-300"
-              >
-                info@presu.com.ar
-              </a>
-            </p>
-          </div>
+            <ol className="flex items-center gap-2">
+              <li>
+                <Link href="/" className="transition-colors hover:text-gray-200">
+                  {navT.home}
+                </Link>
+              </li>
+              <li aria-hidden="true">/</li>
+              <li>
+                <span className="text-gray-100">{t.title}</span>
+              </li>
+            </ol>
+          </nav>
 
-          <div className="mb-8 rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur">
-            <h2 className="mb-4 text-2xl font-bold">{t.faqHeading}</h2>
-            {t.faqs.map((faq, idx) => (
-              <details key={idx} className="mb-4">
-                <summary className="cursor-pointer font-medium">{faq.question}</summary>
-                <p className="mt-2 text-gray-300">{faq.answer}</p>
-              </details>
-            ))}
-          </div>
+          <section className="mx-auto max-w-5xl px-6 sm:px-10">
+            <header className="mb-8 rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+              <h1 className="text-3xl font-extrabold tracking-tight sm:text-5xl">{t.title}</h1>
+              <p className="mt-2 text-sm text-gray-300">{t.intro}</p>
+            </header>
 
-          <div className="rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur">
-            <h2 className="mb-4 text-2xl font-bold">{t.quickLinksHeading}</h2>
-            <ul className="space-y-2">
-              {t.quickLinks.map((link) => (
-                <li key={link.href}>
-                  <a href={link.href} className="text-emerald-400 hover:underline">
-                    {link.label}
-                  </a>
-                </li>
+            <div
+              id="contact"
+              className="mb-8 rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur"
+            >
+              <h2 className="mb-4 text-2xl font-bold">{t.contactHeading}</h2>
+              <p className="text-gray-300">
+                {t.contactDescription}{' '}
+                <a
+                  href={`mailto:info@presu.com.ar?subject=${encodeURIComponent(t.contactMailSubject)}`}
+                  className="underline decoration-emerald-400/50 underline-offset-4 hover:decoration-emerald-300"
+                >
+                  info@presu.com.ar
+                </a>
+              </p>
+            </div>
+
+            <div className="mb-8 rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+              <h2 className="mb-4 text-2xl font-bold">{t.faqHeading}</h2>
+              {t.faqs.map((faq, idx) => (
+                <details key={idx} className="mb-4">
+                  <summary className="cursor-pointer font-medium">{faq.question}</summary>
+                  <p className="mt-2 text-gray-300">{faq.answer}</p>
+                </details>
               ))}
-            </ul>
-            <p className="mt-4 text-sm text-gray-400">
-              {t.lastUpdatedLabel}: {lastUpdated}
-            </p>
-          </div>
-        </section>
-      </main>
+            </div>
+
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+              <h2 className="mb-4 text-2xl font-bold">{t.quickLinksHeading}</h2>
+              <ul className="space-y-2">
+                {t.quickLinks.map((link) => (
+                  <li key={link.href}>
+                    <a href={link.href} className="text-emerald-400 hover:underline">
+                      {link.label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+              <p className="mt-4 text-sm text-gray-400">
+                {t.lastUpdatedLabel}: {lastUpdated}
+              </p>
+            </div>
+          </section>
+        </main>
+        <Footer t={footerT} locale={locale} />
+      </div>
     </>
   )
 }


### PR DESCRIPTION
## Summary
- add site footer and locale-aware footer text to Help page
- refactor layout and navigation link for consistent styling

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: lint errors in existing files)
- `npx eslint src/app/help/HelpClient.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68af3a32f0988326a140741d6f25531f