### PR TITLE
feat: adapt service request for new schema

### DIFF
--- a/src/app/api/request-service/route.ts
+++ b/src/app/api/request-service/route.ts
@@ -18,7 +18,7 @@ type JsonBody = {
   telefono?: string
   tipoPropiedad?: string
   cleaningType?: string
-  frequency?: unknown[]
+  frequency?: string[]
   direccion?: string
   localidad?: string
   mensaje?: string
@@ -140,20 +140,20 @@ export async function POST(request: Request) {
   const insertPayload = {
     user_id: userId?.trim() || null,      // your trigger validates client role if present
     service_id,
-    nombre: nombre || null,
-    email: email || null,
-    telefono: telefono || null,
-    tipo_propiedad: tipoPropiedad || null,
-    cleaning_type: cleaningType || null,
-    frequency,
-    direccion: direccion || null,
-    localidad: localidad || null,
-    mensaje: mensaje || null,
-    sistemas,                             // jsonb
-    invoice_urls: invoiceUrls,            // text[]
-    description,
-    location: localidad || direccion || null,
-    deadline: deadlineDate,
+    service_description: description,
+    service_location: localidad || direccion || null,
+    service_deadline: deadlineDate,
+    user_name: nombre || null,
+    user_email: email || null,
+    user_telephone: telefono || null,
+    user_address: direccion || null,
+    user_city: localidad || null,
+    request_property_type: tipoPropiedad || null,
+    request_cleaning_type: cleaningType || null,
+    request_cleaning_frequency: Array.isArray(frequency) ? frequency.join('/') : null,
+    request_message: mensaje || null,
+    request_systems: sistemas,             // jsonb
+    request_invoice_urls: invoiceUrls,     // text[]
   } as const
 
   const { data: inserted, error: dbErr } = await supabase
@@ -285,7 +285,12 @@ export async function GET(request: Request) {
     const { error } = await supabase
       .schema('api')
       .from('service_requests')
-      .insert({ description: 'smoke', location: 'local', attachments: [] })
+      .insert({
+        service_description: 'smoke',
+        service_location: 'local',
+        request_systems: [],
+        request_invoice_urls: [],
+      })
       .select('id')
       .single()
     return error

--- a/supabase/api-schema.sql
+++ b/supabase/api-schema.sql
@@ -46,13 +46,30 @@ create table if not exists api.provider_services (
 
 -- Service requests placed by users
 create table if not exists api.service_requests (
-  id uuid primary key default gen_random_uuid(),
   user_id uuid references api.profiles(id) on delete set null,
-  description text,
-  location text,
-  deadline date,
-  attachments text[],
-  created_at timestamptz default now()
+  service_id uuid references reference.services(id) on delete set null,
+  provider_id uuid references api.profiles(id) on delete set null,
+  id uuid not null default gen_random_uuid(),
+  service_description text,
+  service_location text,
+  service_deadline date,
+  user_name text,
+  user_email text,
+  user_telephone text,
+  user_address text,
+  user_city text,
+  request_property_type text,
+  request_cleaning_type text,
+  request_cleaning_frequency text,
+  request_message text,
+  provider_assigned_at timestamptz,
+  request_closed_at timestamptz,
+  request_updated_at timestamptz,
+  request_systems jsonb default '[]'::jsonb,
+  request_invoice_urls text[] default array[]::text[],
+  request_status request_status not null default 'open'::request_status,
+  request_created_at timestamptz default now(),
+  constraint service_requests_pkey primary key (id)
 );
 
 -- Ensure service requests come only from client profiles


### PR DESCRIPTION
## Summary
- map service request form to new `service_requests` schema
- update activity page queries for renamed columns
- refresh local `service_requests` table schema

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: eslint errors in unrelated files)*
- `npx eslint src/app/api/request-service/route.ts src/app/activity/ActivityPageClient.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68af48891cb08326adba16f1d2fa8f20