### PR TITLE
feat: adapt service request for new schema

### DIFF
--- a/src/app/api/request-service/route.ts
+++ b/src/app/api/request-service/route.ts
@@ -18,7 +18,7 @@ type JsonBody = {
   telefono?: string
   tipoPropiedad?: string
   cleaningType?: string
-  frequency?: unknown[]
+  frequency?: string[]
   direccion?: string
   localidad?: string
   mensaje?: string
@@ -126,7 +126,22 @@ export async function POST(request: Request) {
     if (!isProd) console.error('Service lookup error:', e)
   }
 
-  // 4) Build description + deadline
+  // 4) Resolve user_id from profiles by email if not provided
+  let user_id = userId?.trim() || null
+  if (!user_id && email?.trim()) {
+    try {
+      const { data: profile } = await supabase
+        .from('profiles')
+        .select('id')
+        .eq('email', email)
+        .maybeSingle()
+      if (profile?.id) user_id = profile.id
+    } catch (e) {
+      if (!isProd) console.error('User lookup error:', e)
+    }
+  }
+
+  // 5) Build description + deadline
   const description =
     (mensaje?.trim() || '') ||
     `[${service || 'Servicio'}] ${tipoPropiedad || ''} ${cleaningType || ''} ${Array.isArray(frequency) ? frequency.join('/') : ''} — ${direccion || ''} ${localidad || ''}`
@@ -136,24 +151,24 @@ export async function POST(request: Request) {
   const deadlineDate =
     deadline && /^\d{4}-\d{2}-\d{2}$/.test(deadline) ? deadline : null
 
-  // 5) Insert (explicit schema header for safety)
+  // 6) Insert (explicit schema header for safety)
   const insertPayload = {
-    user_id: userId?.trim() || null,      // your trigger validates client role if present
+    user_id,      // your trigger validates client role if present
     service_id,
-    nombre: nombre || null,
-    email: email || null,
-    telefono: telefono || null,
-    tipo_propiedad: tipoPropiedad || null,
-    cleaning_type: cleaningType || null,
-    frequency,
-    direccion: direccion || null,
-    localidad: localidad || null,
-    mensaje: mensaje || null,
-    sistemas,                             // jsonb
-    invoice_urls: invoiceUrls,            // text[]
-    description,
-    location: localidad || direccion || null,
-    deadline: deadlineDate,
+    service_description: description,
+    service_location: localidad || direccion || null,
+    service_deadline: deadlineDate,
+    user_name: nombre || null,
+    user_email: email || null,
+    user_telephone: telefono || null,
+    user_address: direccion || null,
+    user_city: localidad || null,
+    request_property_type: tipoPropiedad || null,
+    request_cleaning_type: cleaningType || null,
+    request_cleaning_frequency: Array.isArray(frequency) ? frequency.join('/') : null,
+    request_message: mensaje || null,
+    request_systems: sistemas,             // jsonb
+    request_invoice_urls: invoiceUrls,     // text[]
   } as const
 
   const { data: inserted, error: dbErr } = await supabase
@@ -172,7 +187,7 @@ export async function POST(request: Request) {
     )
   }
 
-  // 6) Email notification
+  // 7) Email notification
   const { SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, SMTP_FROM } = process.env
   if (!SMTP_HOST || !SMTP_PORT || !SMTP_USER || !SMTP_PASS || !SMTP_FROM)
     return NextResponse.json({ error: 'Server misconfigured' }, { status: 500 })
@@ -285,7 +300,12 @@ export async function GET(request: Request) {
     const { error } = await supabase
       .schema('api')
       .from('service_requests')
-      .insert({ description: 'smoke', location: 'local', attachments: [] })
+      .insert({
+        service_description: 'smoke',
+        service_location: 'local',
+        request_systems: [],
+        request_invoice_urls: [],
+      })
       .select('id')
       .single()
     return error

--- a/supabase/api-schema.sql
+++ b/supabase/api-schema.sql
@@ -46,14 +46,39 @@ create table if not exists api.provider_services (
 
 -- Service requests placed by users
 create table if not exists api.service_requests (
-  id uuid primary key default gen_random_uuid(),
   user_id uuid references api.profiles(id) on delete set null,
-  description text,
-  location text,
-  deadline date,
-  attachments text[],
-  created_at timestamptz default now()
+  service_id uuid references reference.services(id) on delete set null,
+  provider_id uuid references api.profiles(id) on delete set null,
+  id uuid not null default gen_random_uuid(),
+  service_description text,
+  service_location text,
+  service_deadline date,
+  user_name text,
+  user_email text,
+  user_telephone text,
+  user_address text,
+  user_city text,
+  request_property_type text,
+  request_cleaning_type text,
+  request_cleaning_frequency text,
+  request_message text,
+  provider_assigned_at timestamptz,
+  request_closed_at timestamptz,
+  request_updated_at timestamptz,
+  request_systems jsonb default '[]'::jsonb,
+  request_invoice_urls text[] default array[]::text[],
+  request_status request_status not null default 'open'::request_status,
+  request_created_at timestamptz default now(),
+  constraint service_requests_pkey primary key (id)
 );
+
+-- automatically track updates
+create extension if not exists moddatetime schema extensions;
+drop trigger if exists handle_updated_at on api.service_requests;
+drop trigger if exists set_updated_at on api.service_requests;
+create trigger set_request_updated_at
+  before insert or update on api.service_requests
+  for each row execute procedure moddatetime(request_updated_at);
 
 -- Ensure service requests come only from client profiles
 create function if not exists api.ensure_client_role()


### PR DESCRIPTION
## Summary
- map service request form to new `service_requests` schema
- update activity page queries for renamed columns
- refresh local `service_requests` table schema
- drop outdated trigger and hook up `request_updated_at` to `moddatetime`
- look up requester profile by email to persist `user_id`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: multiple eslint errors in cards files)*
- `npx eslint src/app/api/request-service/route.ts`

------
https://chatgpt.com/codex/tasks/task_e_68af48891cb08326adba16f1d2fa8f20