### PR TITLE
feat: adapt service request for new schema

### DIFF
--- a/src/app/activity/ActivityPageClient.tsx
+++ b/src/app/activity/ActivityPageClient.tsx
@@ -8,9 +8,9 @@ import { supabase } from '@/lib/supabaseClient'
 
 interface ServiceRequest {
   id: string
-  description: string | null
-  created_at: string
-  status?: string | null
+  service_description: string | null
+  request_created_at: string
+  request_status?: string | null
   service_slug?: string | null
 }
 
@@ -66,11 +66,9 @@ export default function ActivityPage() {
 
   useEffect(() => {
     const fetchServices = async () => {
-      const { data } = await supabase
-        .from('api.services')
-        .select('slug, name_en, name_es')
+      const { data } = await supabase.from('services').select('id, slug, name_en, name_es')
       const map = Object.fromEntries(
-        ((data as { slug: string; name_en: string; name_es: string }[]) || []).map((s) => [s.slug, { name_en: s.name_en, name_es: s.name_es }])
+        ((data as { id: string; slug: string; name_en: string; name_es: string }[]) || []).map((s) => [s.slug, { name_en: s.name_en, name_es: s.name_es }])
       )
       setServiceNames(map)
     }
@@ -107,10 +105,26 @@ export default function ActivityPage() {
       if (userRole === 'client') {
         const { data } = await supabase
           .from('api.service_requests')
-          .select('id, description, created_at, status, service_slug')
+          .select('id, service_description, request_created_at, request_status, service:service_id(slug)')
           .eq('user_id', user.id)
-          .order('created_at', { ascending: false })
-        setRequests((data as ServiceRequest[]) || [])
+          .order('request_created_at', { ascending: false })
+        const rows =
+          (data as {
+            id: string
+            service_description: string | null
+            request_created_at: string
+            request_status?: string | null
+            service?: { slug?: string | null }
+          }[]) || []
+        setRequests(
+          rows.map((r) => ({
+            id: r.id,
+            service_description: r.service_description,
+            request_created_at: r.request_created_at,
+            request_status: r.request_status,
+            service_slug: r.service?.slug ?? null,
+          }))
+        )
       } else if (userRole === 'provider') {
         const { data: offerRows, error } = await supabase
           .from('api.service_request_services')
@@ -131,12 +145,16 @@ export default function ActivityPage() {
         if (ids.length) {
           const { data: reqs } = await supabase
             .from('api.service_requests')
-            .select('id, description, created_at')
+            .select('id, service_description, request_created_at')
             .in('id', ids)
           const reqEntries =
-            (reqs as { id: string; description: string | null; created_at: string }[]) || []
+            (reqs as {
+              id: string
+              service_description: string | null
+              request_created_at: string
+            }[]) || []
           reqData = Object.fromEntries(
-            reqEntries.map((r) => [r.id, { description: r.description, created_at: r.created_at }])
+            reqEntries.map((r) => [r.id, { description: r.service_description, created_at: r.request_created_at }])
           )
         }
         setOffers(
@@ -181,9 +199,9 @@ export default function ActivityPage() {
                 <ActivityCard
                   key={r.id}
                   serviceName={getServiceName(r.service_slug)}
-                  description={r.description || pageT.noDescription}
-                  createdAt={new Date(r.created_at).toLocaleDateString()}
-                  status={getStatusText(r.status)}
+                  description={r.service_description || pageT.noDescription}
+                  createdAt={new Date(r.request_created_at).toLocaleDateString()}
+                  status={getStatusText(r.request_status)}
                 />
               ))}
             {role === 'provider' &&

--- a/supabase/api-schema.sql
+++ b/supabase/api-schema.sql
@@ -46,14 +46,39 @@ create table if not exists api.provider_services (
 
 -- Service requests placed by users
 create table if not exists api.service_requests (
-  id uuid primary key default gen_random_uuid(),
   user_id uuid references api.profiles(id) on delete set null,
-  description text,
-  location text,
-  deadline date,
-  attachments text[],
-  created_at timestamptz default now()
+  service_id uuid references reference.services(id) on delete set null,
+  provider_id uuid references api.profiles(id) on delete set null,
+  id uuid not null default gen_random_uuid(),
+  service_description text,
+  service_location text,
+  service_deadline date,
+  user_name text,
+  user_email text,
+  user_telephone text,
+  user_address text,
+  user_city text,
+  request_property_type text,
+  request_cleaning_type text,
+  request_cleaning_frequency text,
+  request_message text,
+  provider_assigned_at timestamptz,
+  request_closed_at timestamptz,
+  request_updated_at timestamptz,
+  request_systems jsonb default '[]'::jsonb,
+  request_invoice_urls text[] default array[]::text[],
+  request_status request_status not null default 'open'::request_status,
+  request_created_at timestamptz default now(),
+  constraint service_requests_pkey primary key (id)
 );
+
+-- automatically track updates
+create extension if not exists moddatetime schema extensions;
+drop trigger if exists handle_updated_at on api.service_requests;
+drop trigger if exists set_updated_at on api.service_requests;
+create trigger set_request_updated_at
+  before insert or update on api.service_requests
+  for each row execute procedure moddatetime(request_updated_at);
 
 -- Ensure service requests come only from client profiles
 create function if not exists api.ensure_client_role()

--- a/supabase/services.sql
+++ b/supabase/services.sql
@@ -3,7 +3,8 @@ create schema if not exists reference;
 
 -- Services table storing catalog information
 create table if not exists reference.services (
-  slug text primary key,
+  id uuid primary key default gen_random_uuid(),
+  slug text unique,
   name_es text,
   name_en text,
   rating numeric,
@@ -30,7 +31,7 @@ insert into reference.services (slug, name_es, name_en, rating, image_url) value
 -- Exposed view in the api schema
 create schema if not exists api;
 create or replace view api.services as
-  select slug, name_es, name_en, rating, schedule, image_url
+  select id, slug, name_es, name_en, rating, schedule, image_url
   from reference.services;
 
 -- Allow read access to the view for anonymous and authenticated users


### PR DESCRIPTION
## Summary
- map service request form to new `service_requests` schema
- resolve service ids via `api.services` view and persist them with requests
- update activity page to fetch service names from API view
- refresh `services` SQL to include id column and expose it through `api.services`
- drop outdated trigger and hook up `request_updated_at` to `moddatetime`
- look up requester profile by email to persist `user_id`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint errors in card components)*
- `npx eslint src/app/api/request-service/route.ts src/app/activity/ActivityPageClient.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68af48891cb08326adba16f1d2fa8f20