### PR TITLE
Join service requests to services in activity view

### DIFF
--- a/src/app/activity/ActivityPageClient.tsx
+++ b/src/app/activity/ActivityPageClient.tsx
@@ -105,7 +105,9 @@ export default function ActivityPage() {
       if (userRole === 'client') {
         const { data } = await supabase
           .from('api.service_requests')
-          .select('id, service_description, request_created_at, request_status, service:service_id(slug)')
+          .select(
+            'id, service_description, request_created_at, request_status, service:services!inner(slug)'
+          )
           .eq('user_id', user.id)
           .order('request_created_at', { ascending: false })
         const rows =


### PR DESCRIPTION
## Summary
- Join `api.service_requests` with `api.services` when fetching client activity
- Use the join to expose each request's service slug

## Testing
- `npm run lint` *(fails: unused vars, no-html-link-for-pages)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af6fb56c988326afd04969b3d780cf