### PR TITLE
Ensure Supabase key and remove schema prefixes

### DIFF
--- a/src/app/activity/ActivityPageClient.tsx
+++ b/src/app/activity/ActivityPageClient.tsx
@@ -102,7 +102,7 @@ export default function ActivityPage() {
       setLoading(true)
 
       const { data: profile } = await supabase
-        .from('api.profiles')
+        .from('profiles')
         .select('role')
         .eq('id', user.id)
         .single()
@@ -111,7 +111,7 @@ export default function ActivityPage() {
 
       if (userRole === 'client') {
         const { data } = await supabase
-          .from('api.service_requests')
+          .from('service_requests')
           .select(
             'id, service_id, service_description, request_created_at, request_status'
           )
@@ -136,14 +136,14 @@ export default function ActivityPage() {
         )
       } else if (userRole === 'provider') {
         const { data: offerRows, error } = await supabase
-          .from('api.service_request_services')
+          .from('service_request_services')
           .select('request_id, service_slug, status')
           .eq('provider_id', user.id)
         let rows: { request_id: string; service_slug: string; status?: string | null }[] =
           (offerRows as { request_id: string; service_slug: string; status?: string | null }[]) || []
         if (error) {
           const { data: fallback } = await supabase
-            .from('api.service_request_services')
+            .from('service_request_services')
             .select('request_id, service_slug')
             .eq('provider_id', user.id)
           rows =
@@ -153,7 +153,7 @@ export default function ActivityPage() {
         let reqData: Record<string, { description: string | null; created_at: string }> = {}
         if (ids.length) {
           const { data: reqs } = await supabase
-            .from('api.service_requests')
+            .from('service_requests')
             .select('id, service_description, request_created_at')
             .in('id', ids)
           const reqEntries =

--- a/src/app/api/request-service/route.ts
+++ b/src/app/api/request-service/route.ts
@@ -172,7 +172,6 @@ export async function POST(request: Request) {
   } as const
 
   const { data: inserted, error: dbErr } = await supabase
-    .schema('api')
     .from('service_requests')
     .insert(insertPayload)
     .select('id')
@@ -298,7 +297,6 @@ export async function GET(request: Request) {
   if (qs.get('smoke') === '1') {
     const supabase = getSupabaseAdmin()
     const { error } = await supabase
-      .schema('api')
       .from('service_requests')
       .insert({
         service_description: 'smoke',

--- a/src/app/services/ServicesClient.tsx
+++ b/src/app/services/ServicesClient.tsx
@@ -41,7 +41,6 @@ export default function ServicesClient() {
   useEffect(() => {
     const fetchServices = async () => {
       const { data, error } = await supabase
-        .schema('api')
         .from('services')
         .select('*')
 

--- a/src/app/services/[service]/ServiceFormClient.tsx
+++ b/src/app/services/[service]/ServiceFormClient.tsx
@@ -268,7 +268,7 @@ export default function ServiceFormClient({ service }: Props) {
 
     const loadProfile = async () => {
       const { data } = await supabase
-        .from('api.profiles')
+        .from('profiles')
         .select('full_name, phone, address, city')
         .eq('id', user.id)
         .single()

--- a/src/app/settings/SettingsPageClient.tsx
+++ b/src/app/settings/SettingsPageClient.tsx
@@ -51,7 +51,7 @@ export default function SettingsPage() {
       if (!user) return
       setAvatarPath(user.user_metadata?.avatar_url || '')
       const { data } = await supabase
-        .from('api.profiles')
+        .from('profiles')
         .select('full_name, phone, address, city')
         .eq('id', user.id)
         .single()
@@ -87,7 +87,7 @@ export default function SettingsPage() {
     await supabase.auth.updateUser({
       data: { avatar_url: avatarPath, name: fullName, phone, address, city },
     })
-    await supabase.from('api.profiles').upsert({
+    await supabase.from('profiles').upsert({
       id: user.id,
       full_name: fullName,
       phone,

--- a/src/components/sections/home/HeroSection.tsx
+++ b/src/components/sections/home/HeroSection.tsx
@@ -37,7 +37,6 @@ export default function HeroSection({ t, userAddress, locale }: HeroProps) {
   const loadServices = useCallback(async () => {
     if (services.length === 0) {
       const { data } = await supabase
-        .schema('api')
         .from('services')
         .select('slug, name_en, name_es')
 

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,9 +1,7 @@
 import { createClient } from '@supabase/supabase-js'
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-const supabaseAnonKey =
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
-  process.env.SUPABASE_SERVICE_ROLE_KEY
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
 if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error('Missing Supabase environment variables')


### PR DESCRIPTION
## Summary
- ensure Supabase client always receives anon key
- drop hardcoded `api.` prefixes and `.schema('api')` calls

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Do not use an `<a>` element..., `'node' is defined but never used` in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_68b065b185588326968792158743fc5b