### PR TITLE
Add provider profile registration and service selection

### DIFF
--- a/src/app/api/create-user-folder/route.ts
+++ b/src/app/api/create-user-folder/route.ts
@@ -22,6 +22,15 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: profileError.message }, { status: 500 })
     }
 
+    if (role === 'provider') {
+      const { error: providerError } = await supabase
+        .from('providers')
+        .upsert({ id: userId })
+      if (providerError) {
+        return NextResponse.json({ error: providerError.message }, { status: 500 })
+      }
+    }
+
     // All user uploads live in the public "users-data" bucket so
     // ensure that bucket and a folder for this user exist.
     const bucket = 'users-data'

--- a/supabase/api-schema.sql
+++ b/supabase/api-schema.sql
@@ -40,8 +40,8 @@ alter table api.providers drop column if exists services;
 -- Join table linking providers to offered services
 create table if not exists api.provider_services (
   provider_id uuid not null references api.providers(id) on delete cascade,
-  service_slug text not null references reference.services(slug) on delete cascade,
-  primary key (provider_id, service_slug)
+  service_id uuid not null references reference.services(id) on delete cascade,
+  primary key (provider_id, service_id)
 );
 
 -- Service requests placed by users


### PR DESCRIPTION
## Summary
- create provider record when registering a provider
- allow providers to edit company name, tax id and offered services in settings
- switch provider_services table to use service_id references

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: SUPPORTED_LOCALES assigned but only used as type; various no-html-link-for-pages and no-unused-vars errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b08c0a1e808326b46e77ce7049c23e