### PR TITLE
Ensure provider record is created for pro users

### DIFF
--- a/src/app/api/create-user-folder/route.ts
+++ b/src/app/api/create-user-folder/route.ts
@@ -25,8 +25,15 @@ export async function POST(req: Request) {
     if (role === 'provider') {
       const { error: providerError } = await supabase
         .from('providers')
-        .upsert({ id: userId })
-      if (providerError) {
+        .insert({
+          id: userId,
+          company_name: null,
+          tax_id: null,
+          coverage_area: [],
+        })
+        .single()
+
+      if (providerError && providerError.code !== '23505') {
         return NextResponse.json({ error: providerError.message }, { status: 500 })
       }
     }


### PR DESCRIPTION
## Summary
- insert a matching provider record when a user registers with the `provider` role

## Testing
- `npm run lint` *(fails: 'SUPPORTED_LOCALES' is assigned a value but only used as a type, Do not use an `<a>` element to navigate to `/`, 'node' is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_68b090db84b48326b44c708027e0858a