### PR TITLE
Ensure provider record is created for pro users

### DIFF
--- a/src/app/api/create-user-folder/route.ts
+++ b/src/app/api/create-user-folder/route.ts
@@ -7,10 +7,16 @@ export const runtime = 'nodejs'
 
 export async function POST(req: Request) {
   try {
-    const { userId, role = 'client', fullName = '' } = await req.json()
+    const {
+      userId,
+      role: rawRole = 'client',
+      fullName = '',
+    } = await req.json()
     if (!userId) {
       return NextResponse.json({ error: 'Missing userId' }, { status: 400 })
     }
+
+    const role = rawRole === 'pro' ? 'provider' : rawRole
 
     const supabase = getSupabaseAdmin()
 
@@ -25,8 +31,15 @@ export async function POST(req: Request) {
     if (role === 'provider') {
       const { error: providerError } = await supabase
         .from('providers')
-        .upsert({ id: userId })
-      if (providerError) {
+        .insert({
+          id: userId,
+          company_name: null,
+          tax_id: null,
+          coverage_area: [],
+        })
+        .single()
+
+      if (providerError && providerError.code !== '23505') {
         return NextResponse.json({ error: providerError.message }, { status: 500 })
       }
     }


### PR DESCRIPTION
## Summary
- normalize incoming `pro` role to `provider` before persisting profile and provider records
- create default provider entry with matching UUID and empty company, tax, and coverage fields

## Testing
- `npm run lint` *(fails: 'SUPPORTED_LOCALES' is assigned a value but only used as a type, Do not use an `<a>` element to navigate to `/`, 'node' is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_68b090db84b48326b44c708027e0858a