### PR TITLE
fix: preserve profile role on login

### DIFF
--- a/src/app/api/create-user-folder/route.ts
+++ b/src/app/api/create-user-folder/route.ts
@@ -22,7 +22,10 @@ export async function POST(req: Request) {
 
     const { error: profileError } = await supabase
       .from('profiles')
-      .upsert({ id: userId, full_name: fullName, role })
+      .upsert(
+        { id: userId, full_name: fullName, role },
+        { onConflict: 'id', ignoreDuplicates: true }
+      )
 
     if (profileError) {
       return NextResponse.json({ error: profileError.message }, { status: 500 })
@@ -38,7 +41,7 @@ export async function POST(req: Request) {
             tax_id: null,
             coverage_area: [],
           },
-          { onConflict: 'id' }
+          { onConflict: 'id', ignoreDuplicates: true }
         )
 
       if (providerError) {


### PR DESCRIPTION
## Summary
- avoid overwriting existing profile data when creating user folder

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a54b2d888326894410b212758648