### PR TITLE
fix: preserve profile role on login and OAuth signup

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,21 +1,33 @@
 'use client'
 import { useEffect } from 'react'
 import { supabase } from '@/lib/supabaseClient'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 
 export default function CallbackPage() {
   const router = useRouter()
+  const searchParams = useSearchParams()
 
   useEffect(() => {
     const recover = async () => {
       const { data, error } = await supabase.auth.getSession()
       if (data.session) {
+        const role = searchParams.get('role') || undefined
+        const nextParam = searchParams.get('next')
+        const next = nextParam ? decodeURIComponent(nextParam) : '/'
+        const fullName =
+          data.session.user.user_metadata?.full_name ||
+          data.session.user.user_metadata?.name
+
         await fetch('/api/create-user-folder', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ userId: data.session.user.id })
+          body: JSON.stringify({
+            userId: data.session.user.id,
+            role,
+            fullName,
+          }),
         })
-        router.push('/')
+        router.push(next)
       } else {
         console.error('Recovery failed:', error?.message)
         router.push('/auth/login')
@@ -23,7 +35,7 @@ export default function CallbackPage() {
     }
 
     recover()
-  }, [router])
+  }, [router, searchParams])
 
   return <div className="p-6 text-center text-gray-200">Restaurando sesión...</div>
 }

--- a/src/app/auth/register/components/RegisterForm.tsx
+++ b/src/app/auth/register/components/RegisterForm.tsx
@@ -94,7 +94,7 @@ export default function RegisterComponent({ t = defaultT, role = 'client' }: Reg
   const handleGoogleSignup = async () => {
     setGoogleLoading(true)
     // Dynamic OAuth redirectTo with ?next for final destination
-    const oauthRedirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(postAuthRedirect)}${lang ? `&lang=${lang}` : ''}`
+    const oauthRedirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(postAuthRedirect)}${lang ? `&lang=${lang}` : ''}&role=${role}`
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {


### PR DESCRIPTION
## Summary
- keep existing profile role when a user signs in again and update name only
- forward selected role and Google account name through OAuth callback so new providers keep their role

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Do not use an `<a>` element to navigate to `/` and unused vars in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a54b2d888326894410b212758648