### PR TITLE
Align Supabase schema with updated provider relations

### DIFF
--- a/src/app/api/create-user-folder/route.ts
+++ b/src/app/api/create-user-folder/route.ts
@@ -60,8 +60,8 @@ export async function POST(req: Request) {
       const { error: providerError } = await api
         .from('providers')
         .upsert(
-          { id: userId, company_name: null, tax_id: null, coverage_area: [] },
-          { onConflict: 'id', ignoreDuplicates: true }
+          { user_id: userId, company_name: null, tax_id: null, coverage_area: [] },
+          { onConflict: 'user_id', ignoreDuplicates: true }
         )
       if (providerError) return NextResponse.json({ error: providerError.message }, { status: 500 })
     }

--- a/src/app/settings/SettingsPageClient.tsx
+++ b/src/app/settings/SettingsPageClient.tsx
@@ -69,7 +69,7 @@ export default function SettingsPage() {
         const { data: provider } = await supabase
           .from('providers')
           .select('company_name, tax_id, coverage_area')
-          .eq('id', user.id)
+          .eq('user_id', user.id)
           .single()
         setCompanyName(provider?.company_name || '')
         setTaxId(provider?.tax_id || '')
@@ -120,7 +120,7 @@ export default function SettingsPage() {
     })
     if (role === 'provider') {
       await supabase.from('providers').upsert({
-        id: user.id,
+        user_id: user.id,
         company_name: companyName,
         tax_id: taxId,
         coverage_area: city ? [city] : [],

--- a/supabase/providers.sql
+++ b/supabase/providers.sql
@@ -6,7 +6,7 @@ create policy "providers select own"
 on api.providers
 for select
 to authenticated
-using (id = auth.uid());
+using (user_id = auth.uid());
 
 -- INSERT: only the logged-in provider can create their own row,
 -- and only if their profile role is 'provider'
@@ -15,7 +15,7 @@ on api.providers
 for insert
 to authenticated
 with check (
-  id = auth.uid()
+  user_id = auth.uid()
   and exists (
     select 1 from api.profiles p
     where p.id = auth.uid() and p.role = 'provider'
@@ -27,12 +27,12 @@ create policy "providers update own"
 on api.providers
 for update
 to authenticated
-using (id = auth.uid())
-with check (id = auth.uid());
+using (user_id = auth.uid())
+with check (user_id = auth.uid());
 
 -- DELETE: (optional) only delete own row
 create policy "providers delete own"
 on api.providers
 for delete
 to authenticated
-using (id = auth.uid());
+using (user_id = auth.uid());


### PR DESCRIPTION
## Summary
- extend profiles with contact fields and refactor providers to use `user_id` primary key
- update provider RLS policies and joins to reference `user_id`
- simplify activity feed to read `service_requests` for providers

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars, no-html-link-for-pages)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b190ea584c8326bf93435b1bbd8682