### PR TITLE
Improve service selection and editing in settings

### DIFF
--- a/src/app/settings/SettingsPageClient.tsx
+++ b/src/app/settings/SettingsPageClient.tsx
@@ -81,11 +81,43 @@ export default function SettingsPage() {
         const { data: allServices } = await supabase
           .from('services')
           .select('id, name_en, name_es')
-        setServices(allServices || [])
+        const sorted = (allServices || []).sort((a, b) => {
+          const aName = locale === 'es' ? a.name_es : a.name_en
+          const bName = locale === 'es' ? b.name_es : b.name_en
+          return aName.localeCompare(bName)
+        })
+        setServices(sorted)
       }
     }
     loadProfile()
-  }, [user])
+  }, [user, locale])
+
+  useEffect(() => {
+    const fillCity = async () => {
+      if (city) return
+      if (!('geolocation' in navigator) || !('permissions' in navigator)) return
+      try {
+        const status = await navigator.permissions.query({ name: 'geolocation' as PermissionName })
+        if (status.state === 'granted') {
+          navigator.geolocation.getCurrentPosition(async (pos) => {
+            try {
+              const { latitude, longitude } = pos.coords
+              const res = await fetch(`https://api.bigdatacloud.net/data/reverse-geocode-client?latitude=${latitude}&longitude=${longitude}&localityLanguage=${locale === 'es' ? 'es' : 'en'}`)
+              const data = await res.json()
+              const cityName = data.city || data.locality || ''
+              const stateName = data.principalSubdivision || ''
+              if (cityName && stateName) setCity(`${cityName}, ${stateName}`)
+            } catch {
+              // ignore errors
+            }
+          })
+        }
+      } catch {
+        // ignore errors
+      }
+    }
+    fillCity()
+  }, [city, locale])
 
   useEffect(() => {
     const loadAvatar = async () => {
@@ -127,7 +159,8 @@ export default function SettingsPage() {
       })
       await supabase.from('provider_services').delete().eq('provider_id', user.id)
       if (selectedServices.length > 0) {
-        const rows = selectedServices.map((service_id) => ({
+        const uniqueServices = Array.from(new Set(selectedServices))
+        const rows = uniqueServices.map((service_id) => ({
           provider_id: user.id,
           service_id,
         }))
@@ -252,12 +285,9 @@ export default function SettingsPage() {
               onChange={(e) => setPhone(e.target.value)}
               type="tel"
               displayValue={
-                <span className="inline-flex items-center gap-2">
-                  {phone}
-                  {!!phone && (
-                    <FiCheckCircle className="text-green-600" title={pageT.verified} />
-                  )}
-                </span>
+                !!phone && (
+                  <FiCheckCircle className="text-green-600" title={pageT.verified} />
+                )
               }
             />
             <EditableRow
@@ -265,53 +295,41 @@ export default function SettingsPage() {
               value={address}
               onChange={(e) => setAddress(e.target.value)}
             />
-              <EditableRow
-                label={pageT.city}
-                value={city}
-                onChange={(e) => setCity(e.target.value)}
-              />
-              {role === 'provider' && (
-                <>
-                  <EditableRow
-                    label={pageT.companyName}
-                    value={companyName}
-                    onChange={(e) => setCompanyName(e.target.value)}
-                  />
-                  <EditableRow
-                    label={pageT.taxId}
-                    value={taxId}
-                    onChange={(e) => setTaxId(e.target.value)}
-                  />
-                  <div className="py-4">
-                    <div className="text-sm font-semibold text-gray-900">
-                      {pageT.services}
-                    </div>
-                    <div className="mt-1 text-sm text-gray-700 space-y-1">
-                      {services.map((s) => (
-                        <label key={s.id} className="flex items-center gap-2">
-                          <input
-                            type="checkbox"
-                            checked={selectedServices.includes(s.id)}
-                            onChange={() =>
-                              setSelectedServices((prev) =>
-                                prev.includes(s.id)
-                                  ? prev.filter((id) => id !== s.id)
-                                  : [...prev, s.id]
-                              )
-                            }
-                          />
-                          {locale === 'es' ? s.name_es : s.name_en}
-                        </label>
-                      ))}
-                    </div>
+            <EditableRow
+              label={pageT.city}
+              value={city}
+              onChange={(e) => setCity(e.target.value)}
+            />
+            {role === 'provider' && (
+              <>
+                <EditableRow
+                  label={pageT.companyName}
+                  value={companyName}
+                  onChange={(e) => setCompanyName(e.target.value)}
+                />
+                <EditableRow
+                  label={pageT.taxId}
+                  value={taxId}
+                  onChange={(e) => setTaxId(e.target.value)}
+                />
+                <div className="py-4">
+                  <div className="text-sm font-semibold text-gray-900">
+                    {pageT.services}
                   </div>
-                </>
-              )}
-              <Row
-                label={pageT.email}
-                value={
-                  <span className="inline-flex items-center gap-2">
-                    {user.email}
+                  <MultiSelect
+                    options={services}
+                    selected={selectedServices}
+                    onChange={setSelectedServices}
+                    locale={locale}
+                  />
+                </div>
+              </>
+            )}
+            <Row
+              label={pageT.email}
+              value={
+                <span className="inline-flex items-center gap-2">
+                  {user.email}
                   <FiCheckCircle className="text-green-600" title={pageT.verified} />
                 </span>
               }
@@ -358,31 +376,108 @@ function EditableRow({
   type?: string
   displayValue?: React.ReactNode
 }) {
-  const [editing, setEditing] = useState(false)
   return (
-    <div className="py-4 flex items-center justify-between">
+    <div className="py-4 flex items-center justify-between gap-2">
       <div className="flex-1">
         <label className="text-sm font-semibold text-gray-900">{label}</label>
-        {editing ? (
+        <div className="mt-1 flex items-center gap-2">
           <input
             type={type}
             value={value}
             onChange={onChange}
-            onBlur={() => setEditing(false)}
-            autoFocus
-            className="mt-1 text-sm text-gray-900 border border-white rounded-md w-full p-2 focus:outline-none focus:ring-2 focus:ring-black"
+            className="flex-1 text-sm text-gray-900 border border-gray-300 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-black"
           />
-        ) : (
-          <button
-            type="button"
-            onClick={() => setEditing(true)}
-            className="mt-1 text-sm text-gray-700 text-left w-full"
-          >
-            {displayValue ?? value}
-          </button>
-        )}
+          {displayValue}
+        </div>
       </div>
-      {!editing && <FiChevronRight className="text-gray-400 shrink-0" aria-hidden />}
+    </div>
+  )
+}
+
+function MultiSelect({
+  options,
+  selected,
+  onChange,
+  locale,
+}: {
+  options: { id: string; name_en: string; name_es: string }[]
+  selected: string[]
+  onChange: (ids: string[]) => void
+  locale: 'en' | 'es'
+}) {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  const toggleOption = (id: string) => {
+    if (selected.includes(id)) {
+      onChange(selected.filter((s) => s !== id))
+    } else {
+      onChange([...selected, id])
+    }
+  }
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="mt-1 w-full flex flex-wrap items-center gap-1 rounded-md border border-gray-300 bg-white p-2 text-left text-sm focus:outline-none focus:ring-2 focus:ring-black"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        {selected.length === 0 ? (
+          <span className="text-gray-500">
+            {locale === 'es' ? 'Seleccionar servicios' : 'Select services'}
+          </span>
+        ) : (
+          selected.map((id) => {
+            const svc = options.find((o) => o.id === id)
+            const name = locale === 'es' ? svc?.name_es : svc?.name_en
+            return (
+              <span
+                key={id}
+                className="bg-gray-200 rounded px-2 py-0.5 text-xs text-gray-800"
+              >
+                {name}
+              </span>
+            )
+          })
+        )}
+      </button>
+      {open && (
+        <ul className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5">
+          {options.map((s) => {
+            const checked = selected.includes(s.id)
+            const name = locale === 'es' ? s.name_es : s.name_en
+            return (
+              <li
+                key={s.id}
+                className="cursor-pointer select-none p-2 text-sm hover:bg-gray-100"
+              >
+                <label className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => toggleOption(s.id)}
+                    className="rounded border-gray-300"
+                  />
+                  {name}
+                </label>
+              </li>
+            )
+          })}
+        </ul>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Replace provider services checkboxes with an accessible multi-select combo box sorted alphabetically
- Auto-fill city field using geolocation when permission is already granted
- Persist selected services in provider_services join table
- Allow direct editing of settings fields

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, no-unused-vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b1955d0c4c8326bd7c82750c1c69b0