### PR TITLE
Improve service selection and editing in settings

### DIFF
--- a/supabase/provider_services.sql
+++ b/supabase/provider_services.sql
@@ -1,0 +1,31 @@
+-- Ensure RLS is on
+alter table api.provider_services enable row level security;
+
+-- Providers can read their own service associations
+create policy "provider_services select own"
+on api.provider_services
+for select
+to authenticated
+using (provider_id = auth.uid());
+
+-- Providers can add services for themselves
+create policy "provider_services insert own"
+on api.provider_services
+for insert
+to authenticated
+with check (provider_id = auth.uid());
+
+-- Providers can update their own service associations
+create policy "provider_services update own"
+on api.provider_services
+for update
+to authenticated
+using (provider_id = auth.uid())
+with check (provider_id = auth.uid());
+
+-- Providers can remove their own service associations
+create policy "provider_services delete own"
+on api.provider_services
+for delete
+to authenticated
+using (provider_id = auth.uid());


### PR DESCRIPTION
## Summary
- Replace provider services checkboxes with an accessible multi-select combo box sorted alphabetically
- Auto-fill city field using geolocation when permission is already granted
- Persist selected services in provider_services join table
- Allow direct editing of settings fields
- Restrict provider_services access with row-level security policies
- Darken service options for clearer labels
- Enforce E.164 phone format with live validation
- Sync profile, provider, and provider_services rows when saving settings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, no-unused-vars, and other lint errors across the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68b1955d0c4c8326bd7c82750c1c69b0