### PR TITLE
fix: limit hero search suggestions to three items

### DIFF
--- a/src/components/sections/home/HeroSection.tsx
+++ b/src/components/sections/home/HeroSection.tsx
@@ -26,6 +26,8 @@ export default function HeroSection({ t, userAddress, locale }: HeroProps) {
   const [showSuggestions, setShowSuggestions] = useState(false)
   const router = useRouter()
   const searchInputRef = useRef<HTMLInputElement>(null)
+  const touchStartRef = useRef<number | null>(null)
+  const touchMovedRef = useRef(false)
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -121,13 +123,34 @@ export default function HeroSection({ t, userAddress, locale }: HeroProps) {
 
   const renderSuggestions = () =>
     filteredServices.length > 0 && (
-      <ul className="absolute top-full left-0 right-0 mt-1 max-h-60 overflow-auto z-50 bg-white border border-gray-200 rounded-md shadow-lg divide-y divide-gray-100">
+      <ul
+        onMouseDown={(e) => e.preventDefault()}
+        className="absolute top-full left-0 right-0 mt-1 max-h-[7.5rem] overflow-y-auto z-50 bg-white border border-gray-200 rounded-md shadow-lg divide-y divide-gray-100"
+      >
         {filteredServices.map((s) => {
           const name = locale === 'es' ? s.name_es : s.name_en
           return (
             <li
               key={s.slug}
-              onPointerDown={() => handleSelect(s)}
+              onMouseDown={(e) => {
+                e.preventDefault()
+                handleSelect(s)
+              }}
+              onTouchStart={(e) => {
+                touchStartRef.current = e.touches[0].clientY
+                touchMovedRef.current = false
+              }}
+              onTouchMove={(e) => {
+                if (touchStartRef.current !== null) {
+                  const diff = Math.abs(
+                    e.touches[0].clientY - touchStartRef.current
+                  )
+                  if (diff > 10) touchMovedRef.current = true
+                }
+              }}
+              onTouchEnd={() => {
+                if (!touchMovedRef.current) handleSelect(s)
+              }}
               className="px-4 py-2 text-sm text-gray-800 cursor-pointer hover:bg-gray-50 transition-colors"
             >
               {highlightMatch(name)}
@@ -138,7 +161,7 @@ export default function HeroSection({ t, userAddress, locale }: HeroProps) {
     )
 
   return (
-    <section className="relative w-full h-[580px] md:h-[740px] overflow-hidden">
+    <section className="relative w-full h-[580px] md:h-[740px] overflow-x-hidden">
       {/* Rotating background images */}
       {heroImages.map((src, index) => (
         <Image
@@ -182,7 +205,6 @@ export default function HeroSection({ t, userAddress, locale }: HeroProps) {
                   setSearchTerm(e.target.value)
                   setShowSuggestions(true)
                 }}
-                onBlur={() => setTimeout(() => setShowSuggestions(false), 100)}
               />
               <button className="ml-2 p-2 rounded-full hover:bg-gray-100 transition">
                 <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5 text-gray-500" viewBox="0 0 256 256" fill="currentColor">
@@ -191,7 +213,7 @@ export default function HeroSection({ t, userAddress, locale }: HeroProps) {
               </button>
               {renderSuggestions()}
             </div>
-            <button onClick={handleSearch} className="bg-black text-white rounded-full px-6 py-2 text-sm font-medium shadow hover:bg-gray-900 transition">
+            <button onClick={handleSearch} className="w-full bg-black text-white rounded-full px-6 py-2 text-sm font-medium shadow hover:bg-gray-900 transition">
               {t.searchHere}
             </button>
           </div>
@@ -220,7 +242,6 @@ export default function HeroSection({ t, userAddress, locale }: HeroProps) {
                   setSearchTerm(e.target.value)
                   setShowSuggestions(true)
                 }}
-                onBlur={() => setTimeout(() => setShowSuggestions(false), 100)}
               />
               {renderSuggestions()}
             </div>
@@ -230,7 +251,7 @@ export default function HeroSection({ t, userAddress, locale }: HeroProps) {
               </svg>
               <span className="text-gray-700 truncate max-w-[180px]">{userAddress ?? t.location}</span>
             </button>
-            <button onClick={handleSearch} className="bg-black text-white rounded-full px-6 py-3 text-sm font-medium shadow hover:bg-gray-900 transition">
+            <button onClick={handleSearch} className="flex-shrink-0 whitespace-nowrap bg-black text-white rounded-full px-6 py-3 text-sm font-medium shadow hover:bg-gray-900 transition">
               {t.searchHere}
             </button>
           </div>


### PR DESCRIPTION
## Summary
- restrict hero search suggestion dropdown to three scrollable items and prevent accidental taps while scrolling
- allow suggestions to overflow hero section vertically and keep desktop search button width stable

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, no-html-link-for-pages, and other existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b749aa44348326abddba2eacd44904