### PR TITLE
feat: enhance admin activity management

### DIFF
--- a/src/app/activity/ActivityPageClient.tsx
+++ b/src/app/activity/ActivityPageClient.tsx
@@ -22,6 +22,8 @@ interface ServiceRequest {
   request_status?: string | null;
   service_id?: string | null;
   provider_id?: string | null;
+  user_name?: string | null;
+  service_deadline?: string | null;
 }
 
 interface ProviderServiceRow {
@@ -40,6 +42,8 @@ type ActivityItem = {
   status?: string | null;
   serviceId?: string | null;
   providerId?: string | null;
+  userName?: string | null;
+  dueDate?: string | null;
 };
 
 interface PageTranslations {
@@ -51,6 +55,10 @@ interface PageTranslations {
   pending: string;
   closed: string;
   noDescription: string;
+  user: string;
+  due: string;
+  asc: string;
+  desc: string;
 }
 
 // ---------- Pure helpers (exported for tests) ----------
@@ -91,6 +99,14 @@ function formatWhen(iso: string, locale: Locale) {
   return { iso: d.toISOString(), date, time };
 }
 
+function formatDate(iso: string, locale: Locale) {
+  if (!iso) return null;
+  const d = new Date(iso);
+  const tag = LOCALE_TO_BCP47[locale] || "en-US";
+  const date = new Intl.DateTimeFormat(tag, { day: "2-digit", month: "short", year: "numeric" }).format(d);
+  return { iso: d.toISOString(), date };
+}
+
 // -------------------------------------------------------
 
 /**
@@ -103,6 +119,11 @@ function Toolbar({
   setStatus,
   count,
   pageT,
+  user,
+  setUser,
+  order,
+  setOrder,
+  role,
 }: {
   query: string;
   setQuery: (v: string) => void;
@@ -110,6 +131,11 @@ function Toolbar({
   setStatus: (v: "all" | "open" | "assigned" | "pending" | "closed") => void;
   count: number;
   pageT: PageTranslations;
+  user?: string;
+  setUser?: (v: string) => void;
+  order?: "asc" | "desc";
+  setOrder?: (v: "asc" | "desc") => void;
+  role?: "client" | "provider" | "admin";
 }) {
   const pills: Array<{ key: "all" | "open" | "assigned" | "pending" | "closed"; label: string }> = [
     { key: "all", label: pageT.all },
@@ -118,6 +144,7 @@ function Toolbar({
     { key: "pending", label: pageT.pending },
     { key: "closed", label: pageT.closed },
   ];
+  const isAdmin = role === "admin";
 
   return (
     <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
@@ -136,6 +163,14 @@ function Toolbar({
             </svg>
           </span>
         </div>
+        {isAdmin && (
+          <input
+            value={user || ""}
+            onChange={(e) => setUser && setUser(e.target.value)}
+            placeholder={pageT.user}
+            className="w-40 rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm text-neutral-700 placeholder-neutral-400 shadow-[0_1px_0_#0000000d] focus:outline-none focus:ring-2 focus:ring-neutral-900/5"
+          />
+        )}
         <div className="flex items-center gap-1">
           {pills.map((p) => (
             <button
@@ -154,6 +189,16 @@ function Toolbar({
 
       <div className="flex items-center gap-3">
         <span className="text-xs text-neutral-500">{count} {pageT.results}</span>
+        {isAdmin && (
+          <select
+            value={order}
+            onChange={(e) => setOrder && setOrder(e.target.value as "asc" | "desc")}
+            className="rounded-xl border border-neutral-200 bg-white px-2 py-1 text-xs text-neutral-700 shadow-[0_1px_0_#0000000d] focus:outline-none focus:ring-2 focus:ring-neutral-900/5"
+          >
+            <option value="asc">{pageT.asc}</option>
+            <option value="desc">{pageT.desc}</option>
+          </select>
+        )}
       </div>
     </div>
   );
@@ -207,6 +252,10 @@ export default function ActivityPage() {
     noDescription: locale === "es" ? "Sin descripción" : "No description",
     results: locale === "es" ? "resultados" : "results",
     all: locale === "es" ? "Todos" : "All",
+    user: locale === "es" ? "Usuario" : "User",
+    due: locale === "es" ? "Vence" : "Due",
+    asc: locale === "es" ? "Ascendente" : "Ascendant",
+    desc: locale === "es" ? "Descendente" : "Descendant",
   };
   const typedPageT: PageTranslations = {
     searchPlaceholder: t.searchPlaceholder,
@@ -217,6 +266,10 @@ export default function ActivityPage() {
     pending: pageT.pending,
     closed: pageT.closed,
     noDescription: pageT.noDescription,
+    user: pageT.user,
+    due: pageT.due,
+    asc: pageT.asc,
+    desc: pageT.desc,
   };
 
   const user = useUser();
@@ -228,6 +281,8 @@ export default function ActivityPage() {
 
   const [query, setQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState<"all" | "open" | "assigned" | "pending" | "closed">("all");
+  const [userQuery, setUserQuery] = useState("");
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
 
   // -------- fetch helper --------
   const fetchFromApi = async <T,>(path: string, params: URLSearchParams): Promise<T | null> => {
@@ -320,7 +375,8 @@ export default function ActivityPage() {
       setRole(userRole);
       if (userRole === "client") {
         const params = new URLSearchParams({
-          select: "id, service_id, provider_id, service_description, request_created_at, request_status",
+          select:
+            "id, service_id, provider_id, service_description, request_created_at, request_status, user_name, service_deadline",
           user_id: `eq.${user.id}`,
           order: "request_created_at.desc",
         });
@@ -328,7 +384,8 @@ export default function ActivityPage() {
         setRequests(rows);
       } else if (userRole === "provider") {
         const params = new URLSearchParams({
-          select: "id, service_id, provider_id, service_description, request_created_at, request_status",
+          select:
+            "id, service_id, provider_id, service_description, request_created_at, request_status, user_name, service_deadline",
           provider_id: `eq.${user.id}`,
           order: "request_created_at.desc",
         });
@@ -336,8 +393,10 @@ export default function ActivityPage() {
         setRequests(rows);
       } else if (userRole === "admin") {
         const params = new URLSearchParams({
-          select: "id, service_id, provider_id, service_description, request_created_at, request_status",
+          select:
+            "id, service_id, provider_id, service_description, request_created_at, request_status, user_name, service_deadline",
           order: "request_created_at.desc",
+          limit: "1000",
         });
         const rows = (await fetchFromApi<ServiceRequest[]>("service_requests", params)) || [];
         setRequests(rows);
@@ -358,10 +417,25 @@ export default function ActivityPage() {
       status: r.request_status ?? "closed",
       serviceId: r.service_id,
       providerId: r.provider_id,
+      userName: r.user_name,
+      dueDate: r.service_deadline,
     }));
   }, [requests, getServiceName, pageT.noDescription]);
 
-  const filtered = useMemo(() => filterItems(items, query, statusFilter), [items, query, statusFilter]);
+  const filtered = useMemo(() => {
+    const base = filterItems(items, query, statusFilter);
+    const byUser =
+      role === "admin"
+        ? base.filter((it) =>
+            !userQuery || (it.userName || "").toLowerCase().includes(userQuery.toLowerCase())
+          )
+        : base;
+    return [...byUser].sort((a, b) =>
+      sortOrder === "asc"
+        ? new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+        : new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    );
+  }, [items, query, statusFilter, userQuery, sortOrder, role]);
 
   const assignProvider = useCallback(async (requestId: string, providerId: string) => {
     await supabase
@@ -401,6 +475,11 @@ export default function ActivityPage() {
                 setStatus={setStatusFilter}
                 count={filtered.length}
                 pageT={typedPageT}
+                user={userQuery}
+                setUser={setUserQuery}
+                order={sortOrder}
+                setOrder={setSortOrder}
+                role={role}
               />
               {filtered.length ? (
                 <ul className="mt-4 space-y-3">
@@ -414,6 +493,8 @@ export default function ActivityPage() {
                         status={it.status}
                         serviceId={it.serviceId}
                         providerId={it.providerId}
+                        userName={it.userName}
+                        dueDate={it.dueDate}
                       />
                     </li>
                   ))}
@@ -431,10 +512,21 @@ export default function ActivityPage() {
   );
 
   // -------- Local component --------
-  function ActivityCard(props: { id: string; title: string; description: string; createdAt: string; status?: string | null; serviceId?: string | null; providerId?: string | null }) {
-    const { id, title, description, createdAt, status, serviceId, providerId } = props;
+  function ActivityCard(props: {
+    id: string;
+    title: string;
+    description: string;
+    createdAt: string;
+    status?: string | null;
+    serviceId?: string | null;
+    providerId?: string | null;
+    userName?: string | null;
+    dueDate?: string | null;
+  }) {
+    const { id, title, description, createdAt, status, serviceId, providerId, userName, dueDate } = props;
     const meta = statusMeta(status);
     const when = createdAt ? formatWhen(createdAt, locale) : null;
+    const due = dueDate ? formatDate(dueDate, locale) : null;
     const providerOptions = serviceId ? providersByService[serviceId] || [] : [];
     const [selected, setSelected] = useState(providerId || "");
     const assignDisabled = !selected || selected === providerId;
@@ -465,6 +557,17 @@ export default function ActivityPage() {
                   </div>
 
                   <p className="mt-1 text-neutral-700 line-clamp-2 text-sm">{description}</p>
+
+                  {role === "admin" && (
+                    <div className="mt-2 flex flex-col sm:flex-row sm:items-center sm:gap-4 text-[12px] text-neutral-500">
+                      {userName && <span>{userName}</span>}
+                      {due && (
+                        <span>
+                          {pageT.due}: <time dateTime={due.iso}>{due.date}</time>
+                        </span>
+                      )}
+                    </div>
+                  )}
 
                   {when && (
                     <div className="mt-3 inline-flex items-center gap-1.5 text-[12px] text-neutral-500 leading-none">

--- a/src/app/api/create-user-folder/route.ts
+++ b/src/app/api/create-user-folder/route.ts
@@ -42,7 +42,7 @@ export async function POST(req: Request) {
           ? 'provider'
           : (existingProfile.role as 'client' | 'provider')
 
-      const updates: Record<string, any> = {}
+      const updates: Record<string, unknown> = {}
       if (fullName) updates.full_name = fullName
       if (finalRole !== existingProfile.role) updates.role = finalRole
 

--- a/src/app/cards/accessibility-tools/AccessibilityClient.tsx
+++ b/src/app/cards/accessibility-tools/AccessibilityClient.tsx
@@ -5,9 +5,9 @@ import Navbar from '@/components/layout/Navbar'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import Link from 'next/link'
 
-const SUPPORTED_LOCALES = ['en', 'es'] as const
-type Locale = (typeof SUPPORTED_LOCALES)[number]
+type Locale = 'en' | 'es'
 const isLocale = (v: string | null): v is Locale => v === 'en' || v === 'es'
 
 export default function AccessibilityClient() {
@@ -168,11 +168,11 @@ Please include: **URL**, **browser**, **assistive tech**, and **repro steps**, i
           aria-label={locale === 'es' ? 'Miga de pan' : 'Breadcrumb'}
         >
           <ol className="flex items-center gap-2">
-            <li>
-              <a href="/" className="hover:text-gray-200 transition-colors">
-                {t.home}
-              </a>
-            </li>
+              <li>
+                <Link href="/" className="hover:text-gray-200 transition-colors">
+                  {t.home}
+                </Link>
+              </li>
             <li aria-hidden="true">/</li>
             <li>
               <span className="text-gray-300">{t.legal}</span>
@@ -203,35 +203,32 @@ Please include: **URL**, **browser**, **assistive tech**, and **repro steps**, i
           </header>
 
           {/* Markdown Body */}
-          <article className="prose prose-invert max-w-none">
-            <ReactMarkdown
-              remarkPlugins={[remarkGfm]}
-              components={{
-                h2: ({ node, ...props }) => (
-                  <h2 className="mt-8 text-2xl font-bold tracking-tight" {...props} />
-                ),
-                h3: ({ node, ...props }) => (
-                  <h3 className="mt-6 text-xl font-semibold tracking-tight" {...props} />
-                ),
-                p: ({ node, ...props }) => (
-                  <p className="leading-relaxed text-gray-200" {...props} />
-                ),
-                ul: ({ node, ...props }) => <ul className="list-disc pl-6" {...props} />,
-                ol: ({ node, ...props }) => <ol className="list-decimal pl-6" {...props} />,
-                li: ({ node, ...props }) => <li className="my-1" {...props} />,
-                a: ({ node, ...props }) => (
-                  <a className="underline decoration-emerald-400/50 underline-offset-4 hover:decoration-emerald-300" {...props} />
-                ),
-                hr: () => <hr className="my-8 border-white/10" />,
-                blockquote: ({ node, ...props }) => (
-                  <blockquote className="border-l-4 border-emerald-400/50 pl-4 text-gray-200/90" {...props} />
-                ),
-                strong: ({ node, ...props }) => <strong className="text-white" {...props} />,
-              }}
-            >
-              {content.md}
-            </ReactMarkdown>
-          </article>
+            <article className="prose prose-invert max-w-none">
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                components={{
+                  h2: (props) => <h2 className="mt-8 text-2xl font-bold tracking-tight" {...props} />,
+                  h3: (props) => <h3 className="mt-6 text-xl font-semibold tracking-tight" {...props} />,
+                  p: (props) => <p className="leading-relaxed text-gray-200" {...props} />,
+                  ul: (props) => <ul className="list-disc pl-6" {...props} />,
+                  ol: (props) => <ol className="list-decimal pl-6" {...props} />,
+                  li: (props) => <li className="my-1" {...props} />,
+                  a: (props) => (
+                    <a
+                      className="underline decoration-emerald-400/50 underline-offset-4 hover:decoration-emerald-300"
+                      {...props}
+                    />
+                  ),
+                  hr: () => <hr className="my-8 border-white/10" />,
+                  blockquote: (props) => (
+                    <blockquote className="border-l-4 border-emerald-400/50 pl-4 text-gray-200/90" {...props} />
+                  ),
+                  strong: (props) => <strong className="text-white" {...props} />,
+                }}
+              >
+                {content.md}
+              </ReactMarkdown>
+            </article>
         </section>
       </main>
     </>

--- a/src/app/cards/privacy-policy/PrivacyClient.tsx
+++ b/src/app/cards/privacy-policy/PrivacyClient.tsx
@@ -5,9 +5,9 @@ import Navbar from '@/components/layout/Navbar'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import Link from 'next/link'
 
-const SUPPORTED_LOCALES = ['en', 'es'] as const
-type Locale = (typeof SUPPORTED_LOCALES)[number]
+type Locale = 'en' | 'es'
 const isLocale = (v: string | null): v is Locale => v === 'en' || v === 'es'
 
 export default function PrivacyClient() {
@@ -182,12 +182,12 @@ Questions or requests? Contact **info@presu.com.ar**.`,
       <main className="min-h-screen w-full bg-gradient-to-b from-neutral-950 via-black to-neutral-950 text-white pt-28 pb-24">
         {/* Breadcrumb */}
         <nav className="mx-auto mb-6 max-w-5xl px-6 sm:px-10 text-sm text-gray-400">
-          <ol className="flex items-center gap-2">
-            <li>
-              <a href="/" className="hover:text-gray-200 transition-colors">
-                {t.home}
-              </a>
-            </li>
+            <ol className="flex items-center gap-2">
+              <li>
+                <Link href="/" className="hover:text-gray-200 transition-colors">
+                  {t.home}
+                </Link>
+              </li>
             <li aria-hidden="true">/</li>
             <li>
               <span className="text-gray-300">{t.legal}</span>
@@ -221,28 +221,25 @@ Questions or requests? Contact **info@presu.com.ar**.`,
           <article className="prose prose-invert prose-h1:mt-0 prose-headings:scroll-m-20 max-w-none">
             <ReactMarkdown
               remarkPlugins={[remarkGfm]}
-              components={{
-                h2: ({ node, ...props }) => (
-                  <h2 className="mt-8 text-2xl font-bold tracking-tight" {...props} />
-                ),
-                h3: ({ node, ...props }) => (
-                  <h3 className="mt-6 text-xl font-semibold tracking-tight" {...props} />
-                ),
-                p: ({ node, ...props }) => (
-                  <p className="leading-relaxed text-gray-200" {...props} />
-                ),
-                li: ({ node, ...props }) => <li className="my-1" {...props} />,
-                blockquote: ({ node, ...props }) => (
-                  <blockquote className="border-l-4 border-emerald-400/50 pl-4 text-gray-200/90" {...props} />
-                ),
-                hr: () => <hr className="my-8 border-white/10" />,
-                a: ({ node, ...props }) => (
-                  <a className="underline decoration-emerald-400/50 underline-offset-4 hover:decoration-emerald-300" {...props} />
-                ),
-                strong: ({ node, ...props }) => <strong className="text-white" {...props} />,
-                ul: ({ node, ...props }) => <ul className="list-disc pl-6" {...props} />,
-                ol: ({ node, ...props }) => <ol className="list-decimal pl-6" {...props} />,
-              }}
+                components={{
+                  h2: (props) => <h2 className="mt-8 text-2xl font-bold tracking-tight" {...props} />,
+                  h3: (props) => <h3 className="mt-6 text-xl font-semibold tracking-tight" {...props} />,
+                  p: (props) => <p className="leading-relaxed text-gray-200" {...props} />,
+                  li: (props) => <li className="my-1" {...props} />,
+                  blockquote: (props) => (
+                    <blockquote className="border-l-4 border-emerald-400/50 pl-4 text-gray-200/90" {...props} />
+                  ),
+                  hr: () => <hr className="my-8 border-white/10" />,
+                  a: (props) => (
+                    <a
+                      className="underline decoration-emerald-400/50 underline-offset-4 hover:decoration-emerald-300"
+                      {...props}
+                    />
+                  ),
+                  strong: (props) => <strong className="text-white" {...props} />,
+                  ul: (props) => <ul className="list-disc pl-6" {...props} />,
+                  ol: (props) => <ol className="list-decimal pl-6" {...props} />,
+                }}
             >
               {content.md}
             </ReactMarkdown>

--- a/src/app/cards/sitemap/SitemapClient.tsx
+++ b/src/app/cards/sitemap/SitemapClient.tsx
@@ -5,9 +5,8 @@ import Navbar from '@/components/layout/Navbar'
 import Link from 'next/link'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 
-const SUPPORTED_LOCALES = ['en', 'es'] as const
- type Locale = (typeof SUPPORTED_LOCALES)[number]
- const isLocale = (v: string | null): v is Locale => v === 'en' || v === 'es'
+type Locale = 'en' | 'es'
+const isLocale = (v: string | null): v is Locale => v === 'en' || v === 'es'
 
 export default function SitemapClient() {
   const router = useRouter()
@@ -136,12 +135,12 @@ export default function SitemapClient() {
       <Navbar locale={locale} toggleLocale={toggleLocale} t={navT} forceWhite />
       <main className="min-h-screen w-full bg-gradient-to-b from-neutral-950 via-black to-neutral-950 text-white pt-28 pb-24">
         <nav className="mx-auto mb-6 max-w-5xl px-6 sm:px-10 text-sm text-gray-400">
-          <ol className="flex items-center gap-2">
-            <li>
-              <a href="/" className="hover:text-gray-200 transition-colors">
-                {navT.home}
-              </a>
-            </li>
+            <ol className="flex items-center gap-2">
+              <li>
+                <Link href="/" className="hover:text-gray-200 transition-colors">
+                  {navT.home}
+                </Link>
+              </li>
             <li aria-hidden="true">/</li>
             <li>
               <span className="text-gray-100">{content.title}</span>

--- a/src/app/cards/terms-of-use/TermsClient.tsx
+++ b/src/app/cards/terms-of-use/TermsClient.tsx
@@ -5,9 +5,9 @@ import Navbar from '@/components/layout/Navbar'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import Link from 'next/link'
 
-const SUPPORTED_LOCALES = ['en', 'es'] as const
-type Locale = (typeof SUPPORTED_LOCALES)[number]
+type Locale = 'en' | 'es'
 
 function isLocale(v: string | null): v is Locale {
   return v === 'en' || v === 'es'
@@ -141,12 +141,12 @@ Questions? Contact **info@presu.com.ar**.`,
       <main className="min-h-screen w-full bg-gradient-to-b from-neutral-950 via-black to-neutral-950 text-white pt-28 pb-24">
         {/* Breadcrumb */}
         <nav className="mx-auto mb-6 max-w-5xl px-6 sm:px-10 text-sm text-gray-400">
-          <ol className="flex items-center gap-2">
-            <li>
-              <a href="/" className="hover:text-gray-200 transition-colors">
-                {t.home}
-              </a>
-            </li>
+            <ol className="flex items-center gap-2">
+              <li>
+                <Link href="/" className="hover:text-gray-200 transition-colors">
+                  {t.home}
+                </Link>
+              </li>
             <li aria-hidden="true">/</li>
             <li>
               <span className="text-gray-300">{t.legal}</span>
@@ -180,28 +180,25 @@ Questions? Contact **info@presu.com.ar**.`,
           <article className="prose prose-invert prose-h1:mt-0 prose-headings:scroll-m-20 max-w-none">
             <ReactMarkdown
               remarkPlugins={[remarkGfm]}
-              components={{
-                h2: ({ node, ...props }) => (
-                  <h2 className="mt-8 text-2xl font-bold tracking-tight" {...props} />
-                ),
-                h3: ({ node, ...props }) => (
-                  <h3 className="mt-6 text-xl font-semibold tracking-tight" {...props} />
-                ),
-                p: ({ node, ...props }) => (
-                  <p className="leading-relaxed text-gray-200" {...props} />
-                ),
-                li: ({ node, ...props }) => <li className="my-1" {...props} />,
-                blockquote: ({ node, ...props }) => (
-                  <blockquote className="border-l-4 border-emerald-400/50 pl-4 text-gray-200/90" {...props} />
-                ),
-                hr: () => <hr className="my-8 border-white/10" />,
-                a: ({ node, ...props }) => (
-                  <a className="underline decoration-emerald-400/50 underline-offset-4 hover:decoration-emerald-300" {...props} />
-                ),
-                strong: ({ node, ...props }) => <strong className="text-white" {...props} />,
-                ul: ({ node, ...props }) => <ul className="list-disc pl-6" {...props} />,
-                ol: ({ node, ...props }) => <ol className="list-decimal pl-6" {...props} />,
-              }}
+                components={{
+                  h2: (props) => <h2 className="mt-8 text-2xl font-bold tracking-tight" {...props} />,
+                  h3: (props) => <h3 className="mt-6 text-xl font-semibold tracking-tight" {...props} />,
+                  p: (props) => <p className="leading-relaxed text-gray-200" {...props} />,
+                  li: (props) => <li className="my-1" {...props} />,
+                  blockquote: (props) => (
+                    <blockquote className="border-l-4 border-emerald-400/50 pl-4 text-gray-200/90" {...props} />
+                  ),
+                  hr: () => <hr className="my-8 border-white/10" />,
+                  a: (props) => (
+                    <a
+                      className="underline decoration-emerald-400/50 underline-offset-4 hover:decoration-emerald-300"
+                      {...props}
+                    />
+                  ),
+                  strong: (props) => <strong className="text-white" {...props} />,
+                  ul: (props) => <ul className="list-disc pl-6" {...props} />,
+                  ol: (props) => <ol className="list-decimal pl-6" {...props} />,
+                }}
             >
               {content.md}
             </ReactMarkdown>

--- a/supabase/service_requests.sql
+++ b/supabase/service_requests.sql
@@ -1,0 +1,43 @@
+-- Ensure RLS is on
+alter table api.service_requests enable row level security;
+
+-- Allow authenticated users to work with their service requests
+grant usage on schema api to authenticated;
+grant select, insert, update, delete on api.service_requests to authenticated;
+
+-- Clients can view their own requests
+create policy "service_requests select own" on api.service_requests
+for select to authenticated using (user_id = auth.uid());
+
+-- Providers can view assigned requests
+create policy "service_requests select assigned" on api.service_requests
+for select to authenticated using (provider_id = auth.uid());
+
+-- Admins can view all requests
+create policy "service_requests select all" on api.service_requests
+for select to authenticated using (
+  exists (
+    select 1 from api.profiles p
+    where p.id = auth.uid() and p.role = 'admin'
+  )
+);
+
+-- Clients can create their own requests
+create policy "service_requests insert own" on api.service_requests
+for insert to authenticated with check (user_id = auth.uid());
+
+-- Allow updates by owner, assigned provider, or admin
+create policy "service_requests update allowed" on api.service_requests
+for update to authenticated using (
+  user_id = auth.uid()
+  or provider_id = auth.uid()
+  or exists (
+    select 1 from api.profiles p where p.id = auth.uid() and p.role = 'admin'
+  )
+) with check (
+  user_id = auth.uid()
+  or provider_id = auth.uid()
+  or exists (
+    select 1 from api.profiles p where p.id = auth.uid() and p.role = 'admin'
+  )
+);


### PR DESCRIPTION
## Summary
- allow admins to filter activity by user and sort by date
- show username and service deadline on activity cards
- support assigning providers to any matching request
- ensure admin view retrieves all user service requests
- replace anchor tags with Next.js Links across legal pages
- remove explicit any from create-user-folder API
- allow admins to view service requests via row-level security policy

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7722582c88326a0597efab136ef32