### PR TITLE
Improve activity accessibility and attachment preview

### DIFF
--- a/src/app/activity/ActivityPageClient.tsx
+++ b/src/app/activity/ActivityPageClient.tsx
@@ -560,10 +560,21 @@ export default function ActivityPage() {
         request_closed_at: now,
       })
       .eq("id", requestId);
+
+    await supabase
+      .from("service_request_services")
+      .upsert({ request_id: requestId, provider_id: providerId }, { onConflict: "request_id" });
+
     setRequests((prev) =>
       prev.map((r) =>
         r.id === requestId
-          ? { ...r, provider_id: providerId, request_status: "closed", request_closed_at: now }
+          ? {
+              ...r,
+              provider_id: providerId,
+              provider_assigned_at: now,
+              request_status: "closed",
+              request_closed_at: now,
+            }
           : r
       )
     );

--- a/supabase/service_request_services.sql
+++ b/supabase/service_request_services.sql
@@ -1,0 +1,63 @@
+-- Ensure RLS is on
+alter table api.service_request_services enable row level security;
+
+-- Allow authenticated users to interact with service_request_services
+grant usage on schema api to authenticated;
+grant select, insert, update, delete on api.service_request_services to authenticated;
+
+-- Clients can view associations for their own requests
+create policy "service_request_services select own" on api.service_request_services
+for select to authenticated
+using (
+  exists (
+    select 1 from api.service_requests r
+    where r.id = service_request_services.request_id
+      and r.user_id = auth.uid()
+  )
+);
+
+-- Providers can view associations assigned to them
+create policy "service_request_services select assigned" on api.service_request_services
+for select to authenticated
+using (provider_id = auth.uid());
+
+-- Admins can view all associations
+create policy "service_request_services select all" on api.service_request_services
+for select to authenticated
+using (
+  exists (
+    select 1 from api.profiles p where p.id = auth.uid() and p.role = 'admin'
+  )
+);
+
+-- Admins can insert associations
+create policy "service_request_services insert admin" on api.service_request_services
+for insert to authenticated
+with check (
+  exists (
+    select 1 from api.profiles p where p.id = auth.uid() and p.role = 'admin'
+  )
+);
+
+-- Admins can update associations
+create policy "service_request_services update admin" on api.service_request_services
+for update to authenticated
+using (
+  exists (
+    select 1 from api.profiles p where p.id = auth.uid() and p.role = 'admin'
+  )
+)
+with check (
+  exists (
+    select 1 from api.profiles p where p.id = auth.uid() and p.role = 'admin'
+  )
+);
+
+-- Admins can delete associations
+create policy "service_request_services delete admin" on api.service_request_services
+for delete to authenticated
+using (
+  exists (
+    select 1 from api.profiles p where p.id = auth.uid() and p.role = 'admin'
+  )
+);


### PR DESCRIPTION
## Summary
- Localize the service request modal and timeline based on the page's language toggle
- Ensure admin provider assignments show available providers via a new API endpoint
- Allow admins full access to provider records and add breathing room above the activity cards
- Remove provider assignment controls from activity cards so assignments happen only in the modal
- Record provider-service links when admins assign providers and secure the table with admin-only RLS policies

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b89d469c7c8326a91c207612337e84