### PR TITLE
Add spacing between activity filters and card list

### DIFF
--- a/src/app/activity/ActivityPageClient.tsx
+++ b/src/app/activity/ActivityPageClient.tsx
@@ -640,10 +640,10 @@ export default function ActivityPage() {
                 setOrder={setSortOrder}
                 role={role}
               />
-              {filtered.length ? (
-                <ul className="mt-6 space-y-3">
-                  {filtered.map((it) => (
-                    <li key={it.id}>
+                {filtered.length ? (
+                  <ul className="mt-8 space-y-3">
+                    {filtered.map((it) => (
+                      <li key={it.id}>
                       <ActivityCard
                         id={it.id}
                         title={it.title}


### PR DESCRIPTION
## Summary
- add top margin before activity card list

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8bd8ebbc483268de2f039ca74587c