### PR TITLE
Ensure closed requests persist status

### DIFF
--- a/src/app/activity/ActivityPageClient.tsx
+++ b/src/app/activity/ActivityPageClient.tsx
@@ -594,21 +594,28 @@ export default function ActivityPage() {
     );
   }, []);
 
-  const closeRequest = useCallback(async (requestId: string) => {
-    const closedAt = new Date().toISOString();
-    await supabase
-      .from("service_requests")
-      .update({ request_status: "closed", request_closed_at: closedAt })
-      .eq("id", requestId);
-    setRequests((prev) =>
-      prev.map((r) =>
-        r.id === requestId
-          ? { ...r, request_status: "closed", request_closed_at: closedAt }
-          : r
-      )
-    );
-    setActiveItem(null);
-  }, []);
+  const closeRequest = useCallback(
+    async (requestId: string) => {
+      const closedAt = new Date().toISOString();
+      const { error } = await supabase.rpc("close_request", {
+        req_id: requestId,
+      });
+      if (error) {
+        console.error("Failed to close request", error);
+        return;
+      }
+      setRequests((prev) =>
+        prev.map((r) =>
+          r.id === requestId
+            ? { ...r, request_status: "closed", request_closed_at: closedAt }
+            : r
+        )
+      );
+      setActiveItem(null);
+      router.refresh();
+    },
+    [router]
+  );
 
   return (
     <>

--- a/supabase/service_requests.sql
+++ b/supabase/service_requests.sql
@@ -78,3 +78,25 @@ end;
 $$;
 
 grant execute on function api.assign_provider(uuid, uuid) to authenticated;
+
+-- RPC for closing service requests; restricted to admins
+create or replace function api.close_request(req_id uuid)
+returns void
+security definer
+language plpgsql
+as $$
+begin
+  if not exists (
+    select 1 from api.profiles p where p.id = auth.uid() and p.role = 'admin'
+  ) then
+    raise exception 'only admins can close requests';
+  end if;
+
+  update api.service_requests
+    set request_status = 'closed',
+        request_closed_at = now()
+    where id = req_id;
+end;
+$$;
+
+grant execute on function api.close_request(uuid) to authenticated;


### PR DESCRIPTION
## Summary
- Add `close_request` RPC to update service requests status and closed timestamp
- Use RPC when closing a request from the activity page and handle errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8cffad6ec83268d45d33e5d2857d9