### PR TITLE
feat: restrict providers from closing requests

### DIFF
--- a/src/app/activity/ActivityPageClient.tsx
+++ b/src/app/activity/ActivityPageClient.tsx
@@ -716,7 +716,7 @@ export default function ActivityPage() {
           providers={activeItem.serviceId ? providersByService[activeItem.serviceId] || [] : []}
           onClose={() => setActiveItem(null)}
           onAssign={(id, providerId) => assignProvider(id, providerId)}
-          onCloseRequest={(req) => closeRequest(req.id)}
+          onCloseRequest={role === "provider" ? undefined : (req) => closeRequest(req.id)}
           locale={locale}
           t={modalT}
         />

--- a/src/app/activity/ServiceRequestModal.tsx
+++ b/src/app/activity/ServiceRequestModal.tsx
@@ -377,7 +377,7 @@ export default function ServiceRequestModal({
         <div className="flex items-center justify-between gap-3 border-t border-neutral-200 px-6 py-4">
           <div className="text-xs text-neutral-500">ID: {request.id}</div>
           <div className="flex items-center gap-2">
-            {request.request_status !== "closed" && (
+            {request.request_status !== "closed" && role !== "provider" && (
               <button
                 onClick={() => onCloseRequest?.(request)}
                 className="rounded-xl border border-neutral-200 px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50"


### PR DESCRIPTION
## Summary
- block providers from closing service requests
- skip close handler for providers in activity modal

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8d2b68a188326877727f7721c36d5