### PR TITLE
feat: show provider details in requests

### DIFF
--- a/src/app/activity/ActivityPageClient.tsx
+++ b/src/app/activity/ActivityPageClient.tsx
@@ -37,6 +37,13 @@ interface ServiceRequest {
   user_city?: string | null;
   provider_assigned_at?: string | null;
   request_closed_at?: string | null;
+  provider?: {
+    full_name?: string | null;
+    email?: string | null;
+    phone?: string | null;
+    address?: string | null;
+    city?: string | null;
+  } | null;
 }
 
 interface ProviderServiceRow {
@@ -67,6 +74,11 @@ type ActivityItem = {
   userTelephone?: string | null;
   userAddress?: string | null;
   userCity?: string | null;
+  providerName?: string | null;
+  providerPhone?: string | null;
+  providerAddress?: string | null;
+  providerCity?: string | null;
+  providerEmail?: string | null;
   providerAssignedAt?: string | null;
   requestClosedAt?: string | null;
   serviceSlug?: string | null;
@@ -315,6 +327,7 @@ export default function ActivityPage() {
     subtitle: locale === "es" ? "Solicitud de servicio" : "Service Request",
     serviceDetails: locale === "es" ? "Detalles del servicio" : "Service Details",
     requester: locale === "es" ? "Solicitante" : "Requester",
+    provider: locale === "es" ? "Proveedor" : "Provider",
     timeline: locale === "es" ? "Cronograma" : "Timeline",
     attachments: locale === "es" ? "Adjuntos" : "Attachments",
     systems: locale === "es" ? "Sistemas" : "Systems",
@@ -473,7 +486,7 @@ export default function ActivityPage() {
       if (userRole === "client") {
         const params = new URLSearchParams({
           select:
-            "id, service_id, provider_id, service_description, request_created_at, request_status, user_name, service_deadline, request_invoice_urls, service_location, request_message, request_property_type, request_cleaning_type, request_cleaning_frequency, user_email, user_telephone, user_address, user_city, provider_assigned_at, request_closed_at",
+            "id, service_id, provider_id, service_description, request_created_at, request_status, user_name, service_deadline, request_invoice_urls, service_location, request_message, request_property_type, request_cleaning_type, request_cleaning_frequency, user_email, user_telephone, user_address, user_city, provider_assigned_at, request_closed_at, provider:profiles!service_requests_provider_id_fkey(full_name, email, phone, address, city)",
           user_id: `eq.${user.id}`,
           order: "request_created_at.desc",
         });
@@ -482,7 +495,7 @@ export default function ActivityPage() {
       } else if (userRole === "provider") {
         const params = new URLSearchParams({
           select:
-            "id, service_id, provider_id, service_description, request_created_at, request_status, user_name, service_deadline, request_invoice_urls, service_location, request_message, request_property_type, request_cleaning_type, request_cleaning_frequency, user_email, user_telephone, user_address, user_city, provider_assigned_at, request_closed_at",
+            "id, service_id, provider_id, service_description, request_created_at, request_status, user_name, service_deadline, request_invoice_urls, service_location, request_message, request_property_type, request_cleaning_type, request_cleaning_frequency, user_email, user_telephone, user_address, user_city, provider_assigned_at, request_closed_at, provider:profiles!service_requests_provider_id_fkey(full_name, email, phone, address, city)",
           provider_id: `eq.${user.id}`,
           order: "request_created_at.desc",
         });
@@ -491,7 +504,7 @@ export default function ActivityPage() {
       } else if (userRole === "admin") {
         const params = new URLSearchParams({
           select:
-            "id, service_id, provider_id, service_description, request_created_at, request_status, user_name, service_deadline, request_invoice_urls, service_location, request_message, request_property_type, request_cleaning_type, request_cleaning_frequency, user_email, user_telephone, user_address, user_city, provider_assigned_at, request_closed_at",
+            "id, service_id, provider_id, service_description, request_created_at, request_status, user_name, service_deadline, request_invoice_urls, service_location, request_message, request_property_type, request_cleaning_type, request_cleaning_frequency, user_email, user_telephone, user_address, user_city, provider_assigned_at, request_closed_at, provider:profiles!service_requests_provider_id_fkey(full_name, email, phone, address, city)",
           order: "request_created_at.desc",
           limit: "1000",
         });
@@ -528,6 +541,11 @@ export default function ActivityPage() {
       userTelephone: r.user_telephone,
       userAddress: r.user_address,
       userCity: r.user_city,
+      providerName: r.provider?.full_name || null,
+      providerPhone: r.provider?.phone || null,
+      providerAddress: r.provider?.address || null,
+      providerCity: r.provider?.city || null,
+      providerEmail: r.provider?.email || null,
       providerAssignedAt: r.provider_assigned_at,
       requestClosedAt: r.request_closed_at,
       serviceSlug: r.service_id ? serviceNames[r.service_id]?.slug || null : null,
@@ -671,6 +689,11 @@ export default function ActivityPage() {
                         userTelephone={it.userTelephone}
                         userAddress={it.userAddress}
                         userCity={it.userCity}
+                        providerName={it.providerName}
+                        providerPhone={it.providerPhone}
+                        providerAddress={it.providerAddress}
+                        providerCity={it.providerCity}
+                        providerEmail={it.providerEmail}
                         providerAssignedAt={it.providerAssignedAt}
                         requestClosedAt={it.requestClosedAt}
                         serviceSlug={it.serviceSlug}
@@ -711,6 +734,11 @@ export default function ActivityPage() {
             user_telephone: activeItem.userTelephone,
             user_address: activeItem.userAddress,
             user_city: activeItem.userCity,
+            provider_name: activeItem.providerName,
+            provider_email: activeItem.providerEmail,
+            provider_telephone: activeItem.providerPhone,
+            provider_address: activeItem.providerAddress,
+            provider_city: activeItem.providerCity,
           }}
           role={role}
           providers={activeItem.serviceId ? providersByService[activeItem.serviceId] || [] : []}
@@ -745,6 +773,11 @@ export default function ActivityPage() {
     userTelephone?: string | null;
     userAddress?: string | null;
     userCity?: string | null;
+    providerName?: string | null;
+    providerPhone?: string | null;
+    providerAddress?: string | null;
+    providerCity?: string | null;
+    providerEmail?: string | null;
     providerAssignedAt?: string | null;
     requestClosedAt?: string | null;
     serviceSlug?: string | null;

--- a/src/app/activity/ServiceRequestModal.tsx
+++ b/src/app/activity/ServiceRequestModal.tsx
@@ -41,11 +41,17 @@ export interface ServiceRequest {
   user_telephone?: string | null;
   user_address?: string | null;
   user_city?: string | null;
+  provider_name?: string | null;
+  provider_email?: string | null;
+  provider_telephone?: string | null;
+  provider_address?: string | null;
+  provider_city?: string | null;
 }
 export interface ModalTranslations {
   subtitle: string;
   serviceDetails: string;
   requester: string;
+  provider: string;
   timeline: string;
   attachments: string;
   systems: string;
@@ -109,7 +115,7 @@ function StatusBadge({
 
 function SectionLabel({ icon: Icon, children }: { icon: React.ElementType; children: React.ReactNode }) {
   return (
-    <div className="mb-2 inline-flex items-center gap-2 rounded-full bg-neutral-50 px-3 py-1 text-sm font-semibold text-neutral-800">
+    <div className="mb-2 inline-flex items-center gap-2 rounded-full bg-neutral-50 px-3 py-1 text-base font-semibold text-neutral-800">
       <Icon className="h-4 w-4" />
       {children}
     </div>
@@ -129,7 +135,7 @@ function FieldRow({
 }) {
   if (!value) return null;
   const Content = (
-    <div className="flex min-w-0 items-start gap-2 py-1 text-sm text-neutral-700">
+    <div className="ml-4 flex min-w-0 items-start gap-2 py-1 text-sm text-neutral-700">
       <Icon className="mt-0.5 h-4 w-4 flex-none text-neutral-400" />
       <div className="min-w-0">
         {label ? <div className="text-xs font-medium text-neutral-500">{label}</div> : null}
@@ -257,6 +263,12 @@ export default function ServiceRequestModal({
     : [];
   const hasFiles = (request.request_invoice_urls?.length ?? 0) > 0;
   const overdue = request.service_deadline ? new Date(request.service_deadline) < new Date() : false;
+  const showProvider = role === "client" && request.request_status === "assigned";
+  const personName = showProvider ? request.provider_name : request.user_name;
+  const personCity = showProvider ? request.provider_city : request.user_city;
+  const personEmail = showProvider ? request.provider_email : request.user_email;
+  const personPhone = showProvider ? request.provider_telephone : request.user_telephone;
+  const addr = fullAddress(request, showProvider ? "provider" : "user");
 
   return (
     <AnimatePresence>
@@ -342,25 +354,25 @@ export default function ServiceRequestModal({
           </section>
 
           <section>
-            <SectionLabel icon={FiUser}>{t.requester}</SectionLabel>
+            <SectionLabel icon={FiUser}>{showProvider ? t.provider : t.requester}</SectionLabel>
 
             <div className="mb-2 flex items-center gap-3">
               <div className="flex h-9 w-9 items-center justify-center rounded-full bg-neutral-100 text-sm font-semibold text-neutral-600">
-                {getInitials(request.user_name)}
+                {getInitials(personName)}
               </div>
               <div className="min-w-0">
                 <div className="truncate text-sm font-medium text-neutral-800">
-                  {request.user_name || t.unknown}
+                  {personName || t.unknown}
                 </div>
-                {request.user_city ? (
-                  <div className="truncate text-xs text-neutral-500">{request.user_city}</div>
+                {personCity ? (
+                  <div className="truncate text-xs text-neutral-500">{personCity}</div>
                 ) : null}
               </div>
             </div>
 
-            <FieldRow icon={FiMail} label={t.email} value={request.user_email} href={request.user_email ? `mailto:${request.user_email}` : undefined} />
-            <FieldRow icon={FiPhone} label={t.phone} value={request.user_telephone} href={request.user_telephone ? `tel:${request.user_telephone}` : undefined} />
-            <FieldRow icon={FiMapPin} label={t.address} value={fullAddress(request)} href={mapsHref(fullAddress(request))} />
+            <FieldRow icon={FiMail} label={t.email} value={personEmail} href={personEmail ? `mailto:${personEmail}` : undefined} />
+            <FieldRow icon={FiPhone} label={t.phone} value={personPhone} href={personPhone ? `tel:${personPhone}` : undefined} />
+            <FieldRow icon={FiMapPin} label={t.address} value={addr} href={mapsHref(addr)} />
 
             <div className="mt-4">
               <SectionLabel icon={FiCalendar}>{t.timeline}</SectionLabel>
@@ -446,9 +458,12 @@ function getInitials(name?: string | null) {
   return (n[0]?.[0] ?? "").concat(n[1]?.[0] ?? "").toUpperCase();
 }
 
-function fullAddress(r: ServiceRequest) {
-  const parts = [r.user_address, r.user_city].filter(Boolean);
-  return parts.length ? parts.join(", ") : undefined;
+function fullAddress(r: ServiceRequest, type: "user" | "provider" = "user") {
+  const parts =
+    type === "provider"
+      ? [r.provider_address, r.provider_city]
+      : [r.user_address, r.user_city];
+  return parts.filter(Boolean).join(", ") || undefined;
 }
 
 function mapsHref(addr?: string) {


### PR DESCRIPTION
## Summary
- display provider details for clients only when request assigned
- fetch provider email and pass to modal
- enlarge section labels and indent subsection rows

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8d639fb9c8326aea63512dbadf0fc