### PR TITLE
Order services list explicitly

### DIFF
--- a/src/app/services/ServicesClient.tsx
+++ b/src/app/services/ServicesClient.tsx
@@ -50,7 +50,27 @@ export default function ServicesClient() {
       }
 
       const fetched = (data ?? []) as Service[]
-      setServices(fetched)
+
+      const order = [
+        'seguridad',
+        'limpieza',
+        'fumigacion',
+        'mantenimiento-ascensores',
+        'escribania',
+        'community-manager',
+        'traslados-ejecutivos',
+        'salones-infantiles'
+      ]
+      const orderMap: Record<string, number> = {}
+      order.forEach((slug, index) => {
+        orderMap[slug] = index
+      })
+
+      const sorted = [...fetched].sort(
+        (a, b) => (orderMap[a.slug] ?? Infinity) - (orderMap[b.slug] ?? Infinity)
+      )
+
+      setServices(sorted)
     }
     fetchServices()
   }, [])


### PR DESCRIPTION
## Summary
- ensure services page lists available services in a specified order

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8d9e90b688326b51ea716663e54b1