### PR TITLE
Indent timeline items in ServiceRequestModal

### DIFF
--- a/src/app/activity/ServiceRequestModal.tsx
+++ b/src/app/activity/ServiceRequestModal.tsx
@@ -377,7 +377,7 @@ export default function ServiceRequestModal({
 
             <div className="mt-4">
               <SectionLabel icon={FiCalendar}>{t.timeline}</SectionLabel>
-              <div className="space-y-3">
+              <div className="ml-6 space-y-3">
                 <TimelineItem icon={FiClock} title={t.requestedOn} when={fmtDate(request.request_created_at, locale)} />
                 <TimelineItem icon={FiCalendar} title={t.dueBy} when={fmtDateOnly(request.service_deadline, locale)} danger={overdue} />
                 <TimelineItem icon={FiUser} title={t.assignedAt} when={fmtDate(request.provider_assigned_at, locale)} />


### PR DESCRIPTION
## Summary
- Align timeline subitems with requester subitems by adding left margin to the timeline list in `ServiceRequestModal`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b984add7588326a90aefb1e47feba9