### PR TITLE
feat: show provider company info in service requests

### DIFF
--- a/src/app/activity/ActivityPageClient.tsx
+++ b/src/app/activity/ActivityPageClient.tsx
@@ -43,6 +43,8 @@ interface ServiceRequest {
     phone?: string | null;
     address?: string | null;
     city?: string | null;
+    company_name?: string | null;
+    tax_id?: string | null;
   } | null;
 }
 
@@ -75,6 +77,8 @@ type ActivityItem = {
   userAddress?: string | null;
   userCity?: string | null;
   providerName?: string | null;
+  providerCompany?: string | null;
+  providerTaxId?: string | null;
   providerPhone?: string | null;
   providerAddress?: string | null;
   providerCity?: string | null;
@@ -331,6 +335,7 @@ export default function ActivityPage() {
     property: locale === "es" ? "Propiedad" : "Property",
     location: locale === "es" ? "Ubicación" : "Location",
     email: locale === "es" ? "Correo" : "Email",
+    taxId: locale === "es" ? "CUIT" : "Tax ID",
     phone: locale === "es" ? "Teléfono" : "Phone",
     address: locale === "es" ? "Dirección" : "Address",
     requestedOn: locale === "es" ? "Solicitado el" : "Requested on",
@@ -481,7 +486,16 @@ export default function ActivityPage() {
         if (providerIds.length) {
           const res = await fetch(`/api/provider-profiles?ids=${providerIds.join(',')}`);
           if (res.ok) {
-            const profiles: Array<{ id: string; full_name: string | null; email: string | null; phone: string | null; address: string | null; city: string | null }> = await res.json();
+            const profiles: Array<{
+              id: string;
+              full_name: string | null;
+              email?: string | null;
+              phone: string | null;
+              address: string | null;
+              city: string | null;
+              company_name: string | null;
+              tax_id: string | null;
+            }> = await res.json();
             const map = Object.fromEntries(profiles.map((p) => [p.id, p]));
             rows.forEach((r) => {
               if (r.provider_id && map[r.provider_id]) {
@@ -546,6 +560,8 @@ export default function ActivityPage() {
       userAddress: r.user_address,
       userCity: r.user_city,
       providerName: r.provider?.full_name || null,
+      providerCompany: r.provider?.company_name || null,
+      providerTaxId: r.provider?.tax_id || null,
       providerPhone: r.provider?.phone || null,
       providerAddress: r.provider?.address || null,
       providerCity: r.provider?.city || null,
@@ -740,6 +756,8 @@ export default function ActivityPage() {
             user_city: activeItem.userCity,
             provider_id: activeItem.providerId,
             provider_name: activeItem.providerName,
+            provider_company_name: activeItem.providerCompany,
+            provider_tax_id: activeItem.providerTaxId,
             provider_email: activeItem.providerEmail,
             provider_telephone: activeItem.providerPhone,
             provider_address: activeItem.providerAddress,

--- a/src/app/activity/ServiceRequestModal.tsx
+++ b/src/app/activity/ServiceRequestModal.tsx
@@ -43,6 +43,8 @@ export interface ServiceRequest {
   user_city?: string | null;
   provider_id?: string | null;
   provider_name?: string | null;
+  provider_company_name?: string | null;
+  provider_tax_id?: string | null;
   provider_email?: string | null;
   provider_telephone?: string | null;
   provider_address?: string | null;
@@ -61,6 +63,7 @@ export interface ModalTranslations {
   property: string;
   location: string;
   email: string;
+  taxId: string;
   phone: string;
   address: string;
   requestedOn: string;
@@ -272,14 +275,16 @@ export default function ServiceRequestModal({
   let personCity: string | null = null;
   let personEmail: string | null = null;
   let personPhone: string | null = null;
+  let taxId: string | null = null;
   let addr: string | undefined;
 
   if (showProvider) {
     if (request.request_status === "assigned" || (request.request_status === "closed" && providerAssigned)) {
-      personName = request.provider_name || t.unknown;
+      personName = request.provider_company_name || t.unknown;
       personCity = request.provider_city || null;
       personEmail = request.provider_email || null;
       personPhone = request.provider_telephone || null;
+      taxId = request.provider_tax_id || null;
       addr = fullAddress(request, "provider");
     } else if (request.request_status === "open") {
       personName = t.notAssignedYet;
@@ -394,7 +399,15 @@ export default function ServiceRequestModal({
               </div>
             </div>
 
-            <FieldRow icon={FiMail} label={t.email} value={personEmail} href={personEmail ? `mailto:${personEmail}` : undefined} />
+            {!showProvider && (
+              <FieldRow
+                icon={FiMail}
+                label={t.email}
+                value={personEmail}
+                href={personEmail ? `mailto:${personEmail}` : undefined}
+              />
+            )}
+            {showProvider && <FieldRow icon={FiFileText} label={t.taxId} value={taxId} />}
             <FieldRow icon={FiPhone} label={t.phone} value={personPhone} href={personPhone ? `tel:${personPhone}` : undefined} />
             <FieldRow icon={FiMapPin} label={t.address} value={addr} href={mapsHref(addr)} />
 

--- a/src/app/api/provider-profiles/route.ts
+++ b/src/app/api/provider-profiles/route.ts
@@ -12,11 +12,22 @@ export async function GET(request: Request) {
   const ids = idsParam.split(",").filter(Boolean);
   const supabase = getSupabaseAdmin();
   const { data, error } = await supabase
-    .from("profiles")
-    .select("id, full_name, phone, address, city")
-    .in("id", ids);
+    .from("providers")
+    .select(
+      "user_id, company_name, tax_id, profiles(full_name, phone, address, city)"
+    )
+    .in("user_id", ids);
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
-  return NextResponse.json(data || []);
+  const rows = (data || []).map((p) => ({
+    id: p.user_id,
+    full_name: p.profiles?.full_name ?? null,
+    phone: p.profiles?.phone ?? null,
+    address: p.profiles?.address ?? null,
+    city: p.profiles?.city ?? null,
+    company_name: p.company_name ?? null,
+    tax_id: p.tax_id ?? null,
+  }));
+  return NextResponse.json(rows);
 }


### PR DESCRIPTION
## Summary
- fetch provider company and tax ID by joining `providers` with `profiles`
- surface provider company, CUIT, phone and address in service request modal
- add translation and plumbing for tax ID field

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b99268630083268122dae675dbabe9