### PR TITLE
Use signed URLs for service request attachments

### DIFF
--- a/src/app/activity/ServiceRequestModal.tsx
+++ b/src/app/activity/ServiceRequestModal.tsx
@@ -15,6 +15,7 @@ import {
   FiRepeat,
   FiLayers,
 } from "react-icons/fi";
+import { AiFillFilePdf } from "react-icons/ai";
 
 export type RequestStatus = "open" | "assigned" | "closed";
 
@@ -219,12 +220,13 @@ function AttachmentList({ urls }: { urls: string[] }) {
     <ul className="space-y-1">
       {urls.map((url, idx) => {
         const size = sizes[url];
-        const name = url.split("/").pop();
+        const raw = decodeURIComponent(url.split("?")[0].split("/").pop() || "");
+        const name = raw.replace(/^[0-9a-fA-F-]{36}-/, "");
         return (
           <li key={idx} className="flex items-center gap-2 text-sm text-neutral-700">
-            <FiFileText className="h-4 w-4 text-neutral-400" />
-            <a href={url} target="_blank" rel="noreferrer" className="truncate hover:underline">
-              {name || url}
+            <AiFillFilePdf className="h-4 w-4 text-red-500" />
+            <a href={url} download={name} className="truncate hover:underline">
+              {name}
             </a>
             {size ? <span className="text-xs text-neutral-500">({fmt(size)})</span> : null}
           </li>

--- a/src/app/api/request-service/route.ts
+++ b/src/app/api/request-service/route.ts
@@ -90,6 +90,21 @@ export async function POST(request: Request) {
     if (f.type !== 'application/pdf') return NextResponse.json({ error: 'Invalid file type' }, { status: 400 })
   }
 
+  // Ensure invoices bucket exists (private by default)
+  const invoicesBucket = 'invoices'
+  const { data: bucketInfo, error: bucketErr } = await supabase.storage.getBucket(invoicesBucket)
+  if (bucketErr) {
+    if (!isProd) console.error('Bucket fetch failed:', bucketErr)
+    return NextResponse.json({ error: 'Bucket check failed', details: bucketErr.message }, { status: 500 })
+  }
+  if (!bucketInfo) {
+    const { error: createErr } = await supabase.storage.createBucket(invoicesBucket)
+    if (createErr) {
+      if (!isProd) console.error('Bucket creation failed:', createErr)
+      return NextResponse.json({ error: 'Bucket creation failed', details: createErr.message }, { status: 500 })
+    }
+  }
+
   // 2) Upload PDFs
   const invoiceUrls: string[] = []
   const mailAttachments: Mail.Attachment[] = []
@@ -103,8 +118,14 @@ export async function POST(request: Request) {
       if (!isProd) console.error('Upload failed:', upErr)
       return NextResponse.json({ error: 'Upload failed', details: upErr.message }, { status: 500 })
     }
-    const { data: pub } = supabase.storage.from('invoices').getPublicUrl(filePath)
-    invoiceUrls.push(pub.publicUrl)
+    const { data: signed, error: signedErr } = await supabase.storage
+      .from('invoices')
+      .createSignedUrl(filePath, 60 * 60 * 24 * 365) // 1 year
+    if (signedErr) {
+      if (!isProd) console.error('Signed URL creation failed:', signedErr)
+      return NextResponse.json({ error: 'Signed URL failed', details: signedErr.message }, { status: 500 })
+    }
+    invoiceUrls.push(signed.signedUrl)
     mailAttachments.push({ filename: file.name, content: buffer })
   }
 


### PR DESCRIPTION
## Summary
- ensure the `invoices` storage bucket exists without making it public
- generate one-year signed URLs for uploaded service request attachments
- display friendly attachment names with PDF icon and readable size

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9913514c88326802b14f480d9e1b0