### PR TITLE
fix: persist user on refresh

### DIFF
--- a/src/features/auth/useUser.ts
+++ b/src/features/auth/useUser.ts
@@ -10,13 +10,6 @@ export default function useUser() {
   const router = useRouter()
 
   useEffect(() => {
-    const getUser = async () => {
-      const { data } = await supabase.auth.getSession()
-      setUser(data.session?.user ?? null)
-    }
-
-    getUser()
-
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, session) => {


### PR DESCRIPTION
## Summary
- remove initial session fetch in `useUser` to avoid flashing sign-in buttons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b99424bc1c83268e166d62c3cffb85