### PR TITLE
feat: add localized tagline section

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -7,6 +7,7 @@ import HeroSection from '../components/sections/home/HeroSection'
 import CardSection from '../components/sections/home/CardSection'
 import Footer from '../components/layout/Footer'
 import LocationPrompt from '../components/sections/home/LocationPrompt'
+import TaglineSection from '../components/sections/home/TaglineSection'
 
 export default function HomeClient() {
   const searchParams = useSearchParams()
@@ -50,6 +51,8 @@ export default function HomeClient() {
       footerNote: 'Do Not Sell or Share My Personal Information',
       copyright: 'All rights reserved.',
       heroHeadline: 'Choose smarter, save more.',
+      tagline:
+        'At Presu we connect companies with suppliers, offering multiple quotes in one place: easy, fast and transparent.',
       joinAsPro: 'Join as a Pro',
       location: 'Location',
       searchHere: 'Search here',
@@ -74,6 +77,8 @@ export default function HomeClient() {
       footerNote: 'No vender ni compartir mi información personal',
       copyright: 'Todos los derechos reservados.',
       heroHeadline: 'Elegí mejor, ahorrá más.',
+      tagline:
+        'En Presu conectamos empresas con proveedores, ofreciendo múltiples presupuestos en un solo lugar: fácil, rápido y transparente.',
       joinAsPro: 'Unirse como profesional',
       location: 'Ubicación',
       searchHere: 'Buscar',
@@ -93,6 +98,7 @@ export default function HomeClient() {
       <div className="w-full">
         <LocationPrompt t={t} setUserAddress={setUserAddress} />
         <HeroSection locale={locale} t={t} userAddress={userAddress} />
+        <TaglineSection t={t} />
       </div>
       <div className="w-full">
         <CardSection locale={locale} t={t} />

--- a/src/components/sections/home/TaglineSection.tsx
+++ b/src/components/sections/home/TaglineSection.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+interface TaglineSectionProps {
+  t: Record<string, string>
+}
+
+export default function TaglineSection({ t }: TaglineSectionProps) {
+  return (
+    <section className="w-full bg-white py-8 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-4xl mx-auto">
+        <p className="text-center text-lg sm:text-xl text-gray-800 dark:text-gray-200">
+          {t.tagline}
+        </p>
+      </div>
+    </section>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add English and Spanish tagline strings
- render tagline between hero and card sections

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b99c808cd08326b1b85a81386c19d0