### PR TITLE
feat: add localized tagline section

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -7,6 +7,7 @@ import HeroSection from '../components/sections/home/HeroSection'
 import CardSection from '../components/sections/home/CardSection'
 import Footer from '../components/layout/Footer'
 import LocationPrompt from '../components/sections/home/LocationPrompt'
+import TaglineSection from '../components/sections/home/TaglineSection'
 
 export default function HomeClient() {
   const searchParams = useSearchParams()
@@ -50,6 +51,11 @@ export default function HomeClient() {
       footerNote: 'Do Not Sell or Share My Personal Information',
       copyright: 'All rights reserved.',
       heroHeadline: 'Choose smarter, save more.',
+      tagline:
+        'At Presu we connect companies with suppliers, offering multiple quotes in one place: easy, fast and transparent.',
+      easy: 'Easy',
+      fast: 'Fast',
+      transparent: 'Transparent',
       joinAsPro: 'Join as a Pro',
       location: 'Location',
       searchHere: 'Search here',
@@ -74,6 +80,11 @@ export default function HomeClient() {
       footerNote: 'No vender ni compartir mi información personal',
       copyright: 'Todos los derechos reservados.',
       heroHeadline: 'Elegí mejor, ahorrá más.',
+      tagline:
+        'En Presu conectamos empresas con proveedores, ofreciendo múltiples presupuestos en un solo lugar: fácil, rápido y transparente.',
+      easy: 'Fácil',
+      fast: 'Rápido',
+      transparent: 'Transparente',
       joinAsPro: 'Unirse como profesional',
       location: 'Ubicación',
       searchHere: 'Buscar',
@@ -93,6 +104,7 @@ export default function HomeClient() {
       <div className="w-full">
         <LocationPrompt t={t} setUserAddress={setUserAddress} />
         <HeroSection locale={locale} t={t} userAddress={userAddress} />
+        <TaglineSection t={t} />
       </div>
       <div className="w-full">
         <CardSection locale={locale} t={t} />

--- a/src/components/sections/home/TaglineSection.tsx
+++ b/src/components/sections/home/TaglineSection.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+interface TaglineSectionProps {
+  t: Record<string, string>
+}
+
+export default function TaglineSection({ t }: TaglineSectionProps) {
+  const features = [
+    {
+      icon: (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 256 256"
+          fill="currentColor"
+          className="w-6 h-6 text-blue-600"
+          aria-hidden="true"
+        >
+          <path d="M190.15 98.15a8 8 0 0 1 0 11.31l-64 64a8 8 0 0 1-11.31 0l-32-32a8 8 0 0 1 11.31-11.31L120 156.69l58.34-58.34a8 8 0 0 1 11.31 0Z" />
+        </svg>
+      ),
+      label: t.easy,
+    },
+    {
+      icon: (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          className="w-6 h-6 text-blue-600"
+          aria-hidden="true"
+        >
+          <path d="M13 10V3L4 14h7v7l9-11h-7z" />
+        </svg>
+      ),
+      label: t.fast,
+    },
+    {
+      icon: (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 256 256"
+          fill="currentColor"
+          className="w-6 h-6 text-blue-600"
+          aria-hidden="true"
+        >
+          <path d="M128 56a120.15 120.15 0 0 0-104.69 61.45 8 8 0 0 0 0 7.1A120.15 120.15 0 0 0 128 184a120.15 120.15 0 0 0 104.69-61.45 8 8 0 0 0 0-7.1A120.15 120.15 0 0 0 128 56Zm0 112a48 48 0 1 1 48-48 48.05 48.05 0 0 1-48 48Zm0-80a32 32 0 1 0 32 32 32 32 0 0 0-32-32Z" />
+        </svg>
+      ),
+      label: t.transparent,
+    },
+  ]
+
+  return (
+    <section className="w-full bg-white py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-4xl mx-auto text-center">
+        <p className="text-xl sm:text-2xl text-gray-800 dark:text-gray-200 font-semibold">
+          {t.tagline}
+        </p>
+        <div className="mt-6 flex flex-col sm:flex-row justify-center gap-6">
+          {features.map((f, idx) => (
+            <div
+              key={idx}
+              className="flex items-center justify-center gap-2 text-gray-700 dark:text-gray-300"
+            >
+              {f.icon}
+              <span className="text-sm font-medium">{f.label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add English and Spanish tagline strings with accompanying feature labels
- render styled tagline section with icons between hero and card sections

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b99c808cd08326b1b85a81386c19d0