### PR TITLE
Show provider email in ServiceRequestModal for clients

### DIFF
--- a/src/app/activity/ServiceRequestModal.tsx
+++ b/src/app/activity/ServiceRequestModal.tsx
@@ -437,14 +437,12 @@ export default function ServiceRequestModal({
               </div>
             </div>
 
-            {!showProvider && (
-              <FieldRow
-                icon={FiMail}
-                label={t.email}
-                value={personEmail}
-                href={personEmail ? `mailto:${personEmail}` : undefined}
-              />
-            )}
+            <FieldRow
+              icon={FiMail}
+              label={t.email}
+              value={personEmail}
+              href={personEmail ? `mailto:${personEmail}` : undefined}
+            />
             {showProvider && <FieldRow icon={FiFileText} label={t.taxId} value={taxId} />}
             <FieldRow icon={FiPhone} label={t.phone} value={personPhone} href={personPhone ? `tel:${personPhone}` : undefined} />
             <FieldRow icon={FiMapPin} label={t.address} value={addr} href={mapsHref(addr)} />


### PR DESCRIPTION
## Summary
- ensure ServiceRequestModal displays provider email for clients and admins

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9a26aa4308326ad182703dbda4761