### PR TITLE
Apply uniform spacing between home sections

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -101,12 +101,10 @@ export default function HomeClient() {
   return (
     <div className="min-h-screen bg-white text-gray-900 dark:bg-gray-950 dark:text-white">
       <Navbar locale={locale} toggleLocale={toggleLocale} t={t} />
-      <div className="w-full">
+      <div className="w-full space-y-24">
         <LocationPrompt t={t} setUserAddress={setUserAddress} />
         <HeroSection locale={locale} t={t} userAddress={userAddress} />
         <TaglineSection t={t} />
-      </div>
-      <div className="w-full">
         <CardSection locale={locale} t={t} />
         <Footer t={t} locale={locale} />
       </div>


### PR DESCRIPTION
## Summary
- extend spacing between home page sections by wrapping them in a single container with consistent vertical gaps

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts from Google Fonts; build failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a7e341448326bf8867fd7a20630c