### PR TITLE
Show provider company name and CUIT in ServiceRequestModal

### DIFF
--- a/src/app/activity/ServiceRequestModal.tsx
+++ b/src/app/activity/ServiceRequestModal.tsx
@@ -273,7 +273,6 @@ export default function ServiceRequestModal({
       personEmail = request.provider_email || null;
       personPhone = request.provider_telephone || null;
       taxId = request.provider_tax_id || null;
-      addr = fullAddress(request, "provider");
     } else if (request.request_status === "open") {
       personName = t.notAssignedYet;
     } else {
@@ -437,17 +436,17 @@ export default function ServiceRequestModal({
               </div>
             </div>
 
-            {!showProvider && (
-              <FieldRow
-                icon={FiMail}
-                label={t.email}
-                value={personEmail}
-                href={personEmail ? `mailto:${personEmail}` : undefined}
-              />
-            )}
             {showProvider && <FieldRow icon={FiFileText} label={t.taxId} value={taxId} />}
+            <FieldRow
+              icon={FiMail}
+              label={t.email}
+              value={personEmail}
+              href={personEmail ? `mailto:${personEmail}` : undefined}
+            />
             <FieldRow icon={FiPhone} label={t.phone} value={personPhone} href={personPhone ? `tel:${personPhone}` : undefined} />
-            <FieldRow icon={FiMapPin} label={t.address} value={addr} href={mapsHref(addr)} />
+            {!showProvider && (
+              <FieldRow icon={FiMapPin} label={t.address} value={addr} href={mapsHref(addr)} />
+            )}
 
             <div className="mt-8">
               <SectionLabel icon={FiCalendar}>{t.timeline}</SectionLabel>

--- a/src/app/api/provider-profiles/route.ts
+++ b/src/app/api/provider-profiles/route.ts
@@ -14,21 +14,29 @@ export async function GET(request: Request) {
   const { data, error } = await supabase
     .from("providers")
     .select(
-      "user_id, company_name, tax_id, profiles(full_name, email, phone, address, city)"
+      "user_id, company_name, tax_id, profiles(full_name, phone, address, city)"
     )
     .in("user_id", ids);
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
-  const rows = (data || []).map((p) => ({
-    id: p.user_id,
-    full_name: p.profiles?.full_name ?? null,
-    email: p.profiles?.email ?? null,
-    phone: p.profiles?.phone ?? null,
-    address: p.profiles?.address ?? null,
-    city: p.profiles?.city ?? null,
-    company_name: p.company_name ?? null,
-    tax_id: p.tax_id ?? null,
-  }));
+
+  const rows = await Promise.all(
+    (data || []).map(async (p) => {
+      const { data: userData } = await supabase.auth.admin.getUserById(
+        p.user_id
+      );
+      return {
+        id: p.user_id,
+        full_name: p.profiles?.full_name ?? null,
+        email: userData.user?.email ?? null,
+        phone: p.profiles?.phone ?? null,
+        address: p.profiles?.address ?? null,
+        city: p.profiles?.city ?? null,
+        company_name: p.company_name ?? null,
+        tax_id: p.tax_id ?? null,
+      };
+    })
+  );
   return NextResponse.json(rows);
 }


### PR DESCRIPTION
## Summary
- ensure ServiceRequestModal displays provider email for clients and admins
- show provider company name with location, CUIT before email, and omit address

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9a26aa4308326ad182703dbda4761