### PR TITLE
feat: show provider company name and tax ID

### DIFF
--- a/src/app/activity/ServiceRequestModal.tsx
+++ b/src/app/activity/ServiceRequestModal.tsx
@@ -265,10 +265,10 @@ export default function ServiceRequestModal({
 
   if (showProvider) {
     if (request.request_status === "assigned" || (request.request_status === "closed" && providerAssigned)) {
-      personName =
-        request.provider_company_name ||
-        request.provider_name ||
-        t.unknown;
+      // Prefer the provider's company name when a provider is assigned.
+      // We intentionally avoid falling back to the username to keep the
+      // focus on the company identity.
+      personName = request.provider_company_name || t.unknown;
       personCity = request.provider_city || null;
       personEmail = request.provider_email || null;
       personPhone = request.provider_telephone || null;
@@ -436,13 +436,24 @@ export default function ServiceRequestModal({
               </div>
             </div>
 
-            {showProvider && <FieldRow icon={FiFileText} label={t.taxId} value={taxId} />}
-            <FieldRow
-              icon={FiMail}
-              label={t.email}
-              value={personEmail}
-              href={personEmail ? `mailto:${personEmail}` : undefined}
-            />
+            {showProvider ? (
+              <>
+                <FieldRow icon={FiFileText} label={t.taxId} value={taxId} />
+                <FieldRow
+                  icon={FiMail}
+                  label={t.email}
+                  value={personEmail}
+                  href={personEmail ? `mailto:${personEmail}` : undefined}
+                />
+              </>
+            ) : (
+              <FieldRow
+                icon={FiMail}
+                label={t.email}
+                value={personEmail}
+                href={personEmail ? `mailto:${personEmail}` : undefined}
+              />
+            )}
             <FieldRow icon={FiPhone} label={t.phone} value={personPhone} href={personPhone ? `tel:${personPhone}` : undefined} />
             {!showProvider && (
               <FieldRow icon={FiMapPin} label={t.address} value={addr} href={mapsHref(addr)} />


### PR DESCRIPTION
## Summary
- prioritize provider company name over username in service request modal
- display CUIT above email and hide provider address for clients

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9ae49cecc83269007b3c860799447