### PR TITLE
Improve Activity page responsiveness on mobile

### DIFF
--- a/src/app/activity/ActivityPageClient.tsx
+++ b/src/app/activity/ActivityPageClient.tsx
@@ -188,7 +188,7 @@ function Toolbar({
 
   return (
     <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         <div className="relative">
           <label htmlFor="activity-search" className="sr-only">
             {pageT.searchPlaceholder}
@@ -220,7 +220,7 @@ function Toolbar({
             />
           </div>
         )}
-        <div className="flex items-center gap-1" role="group" aria-label={pageT.filterLabel}>
+        <div className="flex flex-wrap items-center gap-1" role="group" aria-label={pageT.filterLabel}>
           {pills.map((p) => (
             <button
               key={p.key}
@@ -659,7 +659,7 @@ export default function ActivityPage() {
     <>
       <Navbar locale={locale} toggleLocale={toggleLocale} t={t} forceWhite />
       <div className="bg-white min-h-screen pt-32">
-        <div className="max-w-6xl mx-auto px-6 py-8">
+        <div className="max-w-6xl mx-auto px-4 py-8 sm:px-6">
           <h1 className="text-3xl font-semibold tracking-tight text-black mb-6">{pageT.title}</h1>
 
           {loading ? (
@@ -812,7 +812,7 @@ export default function ActivityPage() {
 
     return (
       <motion.div
-        className="group relative w-[70%] mx-auto cursor-pointer"
+        className="group relative w-full sm:w-[70%] mx-auto cursor-pointer"
         aria-label={`${title} – ${meta.label}`}
         initial={{ opacity: 0, y: 6 }}
         animate={{ opacity: 1, y: 0 }}
@@ -911,7 +911,7 @@ export default function ActivityPage() {
 
 function SkeletonCard() {
   return (
-    <div className="w-[70%] mx-auto flex overflow-hidden rounded-2xl border border-neutral-200 bg-white shadow-[0_1px_0_#0000000d]">
+    <div className="w-full sm:w-[70%] mx-auto flex overflow-hidden rounded-2xl border border-neutral-200 bg-white shadow-[0_1px_0_#0000000d]">
       <div className="w-1.5 bg-neutral-200" aria-hidden />
       <div className="w-full p-5">
         <div className="h-4 w-40 bg-neutral-200 rounded" />


### PR DESCRIPTION
## Summary
- ensure Activity cards and skeletons span full width on small screens
- adjust Activity page container padding for better mobile spacing
- allow Activity filter controls to wrap so pills stay visible on narrow screens

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b51b26548326930a73a6f0a728c8