### PR TITLE
Add consistent spacing to services screens

### DIFF
--- a/src/app/services/ServicesClient.tsx
+++ b/src/app/services/ServicesClient.tsx
@@ -3,10 +3,12 @@
 import { useEffect, useState } from 'react'
 import Image from 'next/image'
 import Navbar from '@/components/layout/Navbar'
+import Footer from '@/components/layout/Footer'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabaseClient'
 import type { Service } from '@/lib/serviceCatalog'
 import { upcomingServices } from '@/lib/serviceCatalog'
+import { getFooterTranslations } from '@/lib/footerTranslations'
 
 export default function ServicesClient() {
   const [locale, setLocale] = useState<'en' | 'es'>('es')
@@ -121,6 +123,8 @@ export default function ServicesClient() {
     )
   }
 
+  const footerT = getFooterTranslations(locale)
+
   return (
     <div className="min-h-screen bg-white text-black">
       <Navbar
@@ -136,22 +140,25 @@ export default function ServicesClient() {
         }}
       />
 
-      <main className="pt-24 px-4 sm:px-8 max-w-7xl mx-auto">
-        <h1 className="text-2xl sm:text-3xl font-bold mb-6">{t.availableTitle}</h1>
+      <main className="pt-24 pb-24 px-4 sm:px-8 max-w-7xl mx-auto space-y-24">
+        <section>
+          <h1 className="text-2xl sm:text-3xl font-bold mb-6">{t.availableTitle}</h1>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-          {services.map((s) => renderCard(s))}
-        </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+            {services.map((s) => renderCard(s))}
+          </div>
+        </section>
 
         {upcomingServices.length > 0 && (
-          <>
-            <h2 className="text-2xl sm:text-3xl font-bold mt-12 mb-6">{t.upcomingTitle}</h2>
+          <section>
+            <h2 className="text-2xl sm:text-3xl font-bold mb-6">{t.upcomingTitle}</h2>
             <div className="flex gap-6 overflow-x-auto pb-2">
               {upcomingServices.map((s) => renderCard(s, 'w-64 flex-shrink-0'))}
             </div>
-          </>
+          </section>
         )}
       </main>
+      <Footer t={footerT} locale={locale} />
     </div>
   )
 }

--- a/src/app/services/[service]/ServiceFormClient.tsx
+++ b/src/app/services/[service]/ServiceFormClient.tsx
@@ -6,6 +6,7 @@ import useUser from '@/features/auth/useUser'
 import Image from 'next/image'
 import Navbar from '@/components/layout/Navbar'
 import Footer from '@/components/layout/Footer'
+import { getFooterTranslations } from '@/lib/footerTranslations'
 import Stepper from '@/components/ui/Stepper'
 import { supabase } from '@/lib/supabaseClient'
 
@@ -370,17 +371,7 @@ export default function ServiceFormClient({ service }: Props) {
     howItWorks: ''
   }
 
-  const footerT = {
-    terms: locale === 'es' ? 'Términos de uso' : 'Terms of Use',
-    privacy: locale === 'es' ? 'Política de privacidad' : 'Privacy Policy',
-    sitemap: locale === 'es' ? 'Mapa del sitio' : 'Sitemap',
-    accessibility: locale === 'es' ? 'Accesibilidad' : 'Accessibility',
-    footerNote:
-      locale === 'es'
-        ? 'No vender ni compartir mi información personal'
-        : 'Do Not Sell or Share My Personal Information',
-    copyright: locale === 'es' ? 'Todos los derechos reservados.' : 'All rights reserved.'
-  }
+  const footerT = getFooterTranslations(locale)
 
   const stepLabels =
     locale === 'es'
@@ -390,7 +381,7 @@ export default function ServiceFormClient({ service }: Props) {
   return (
     <div className="min-h-screen flex flex-col bg-white text-gray-900 dark:bg-gray-950 dark:text-white">
       <Navbar locale={locale} toggleLocale={toggleLocale} t={navT} forceWhite />
-      <main className="flex-grow pt-24 pb-12">
+      <main className="flex-grow pt-24 pb-24">
         {info.image && (
           <div className="relative w-full h-48 md:h-64">
             <Image

--- a/src/lib/footerTranslations.ts
+++ b/src/lib/footerTranslations.ts
@@ -1,0 +1,16 @@
+export function getFooterTranslations(locale: 'en' | 'es') {
+  return {
+    terms: locale === 'es' ? 'Términos de uso' : 'Terms of Use',
+    privacy: locale === 'es' ? 'Política de privacidad' : 'Privacy Policy',
+    sitemap: locale === 'es' ? 'Mapa del sitio' : 'Sitemap',
+    accessibility: locale === 'es' ? 'Accesibilidad' : 'Accessibility',
+    footerNote:
+      locale === 'es'
+        ? 'No vender ni compartir mi información personal'
+        : 'Do Not Sell or Share My Personal Information',
+    copyright:
+      locale === 'es'
+        ? 'Todos los derechos reservados.'
+        : 'All rights reserved.',
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable footer translation helper
- ensure services list uses consistent section spacing and footer
- align service request form padding with global spacing

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b9b88e20808326925ef27242c16016