### PR TITLE
Reduce font size of legal and help page headers

### DIFF
--- a/src/app/cards/accessibility-tools/AccessibilityClient.tsx
+++ b/src/app/cards/accessibility-tools/AccessibilityClient.tsx
@@ -189,7 +189,7 @@ Please include: **URL**, **browser**, **assistive tech**, and **repro steps**, i
           <header className="mb-8 rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur">
             <div className="flex flex-wrap items-center justify-between gap-4">
               <div>
-                <h1 className="text-3xl sm:text-5xl font-extrabold tracking-tight">
+                <h1 className="text-2xl sm:text-3xl font-extrabold tracking-tight">
                   {content.title}
                 </h1>
                 <p className="mt-2 inline-flex items-center gap-2 text-sm text-gray-300">

--- a/src/app/cards/privacy-policy/PrivacyClient.tsx
+++ b/src/app/cards/privacy-policy/PrivacyClient.tsx
@@ -204,7 +204,7 @@ Questions or requests? Contact **info@presu.com.ar**.`,
           <header className="mb-8 rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur">
             <div className="flex flex-wrap items-center justify-between gap-4">
               <div>
-                <h1 className="text-3xl sm:text-5xl font-extrabold tracking-tight">
+                <h1 className="text-2xl sm:text-3xl font-extrabold tracking-tight">
                   {content.title}
                 </h1>
                 <p className="mt-2 inline-flex items-center gap-2 text-sm text-gray-300">

--- a/src/app/cards/sitemap/SitemapClient.tsx
+++ b/src/app/cards/sitemap/SitemapClient.tsx
@@ -152,7 +152,7 @@ export default function SitemapClient() {
           <header className="mb-8 rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur">
             <div className="flex flex-wrap items-center justify-between gap-4">
               <div>
-                <h1 className="text-3xl sm:text-5xl font-extrabold tracking-tight">{content.title}</h1>
+                <h1 className="text-2xl sm:text-3xl font-extrabold tracking-tight">{content.title}</h1>
                 <p className="mt-2 inline-flex items-center gap-2 text-sm text-gray-300">
                   <span className="inline-flex items-center rounded-full border border-emerald-400/30 bg-emerald-400/10 px-2.5 py-0.5">
                     <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 mr-2" />

--- a/src/app/cards/terms-of-use/TermsClient.tsx
+++ b/src/app/cards/terms-of-use/TermsClient.tsx
@@ -163,7 +163,7 @@ Questions? Contact **info@presu.com.ar**.`,
           <header className="mb-8 rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur">
             <div className="flex flex-wrap items-center justify-between gap-4">
               <div>
-                <h1 className="text-3xl sm:text-5xl font-extrabold tracking-tight">
+                <h1 className="text-2xl sm:text-3xl font-extrabold tracking-tight">
                   {content.title}
                 </h1>
                 <p className="mt-2 inline-flex items-center gap-2 text-sm text-gray-300">

--- a/src/app/help/HelpClient.tsx
+++ b/src/app/help/HelpClient.tsx
@@ -122,7 +122,7 @@ export default function HelpClient() {
 
           <section className="mx-auto max-w-5xl px-6 sm:px-10">
             <header className="mb-8 rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur">
-              <h1 className="text-3xl font-extrabold tracking-tight sm:text-5xl">{t.title}</h1>
+              <h1 className="text-2xl font-extrabold tracking-tight sm:text-3xl">{t.title}</h1>
               <p className="mt-2 text-sm text-gray-300">{t.intro}</p>
             </header>
 


### PR DESCRIPTION
## Summary
- Shrink header text for Terms of Use, Privacy Policy, Sitemap, Accessibility Tools, and Help pages to improve visual balance.

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9b9ad000883268c0326b765863832