### PR TITLE
Handle OAuth redirects for dev and hide tokens

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -9,7 +9,7 @@ export default function CallbackPage() {
 
   useEffect(() => {
     const recover = async () => {
-      const { data, error } = await supabase.auth.getSession()
+      const { data, error } = await supabase.auth.getSessionFromURL()
       if (data.session) {
         const role = searchParams.get('role') || undefined
         const nextParam = searchParams.get('next')
@@ -27,7 +27,21 @@ export default function CallbackPage() {
             fullName,
           }),
         })
-        router.push(next)
+
+        // Remove tokens from URL after session is stored
+        if (typeof window !== 'undefined') {
+          window.history.replaceState(
+            {},
+            document.title,
+            window.location.pathname + window.location.search
+          )
+        }
+
+        if (/^https?:\/\//.test(next)) {
+          window.location.href = next
+        } else {
+          router.push(next)
+        }
       } else {
         console.error('Recovery failed:', error?.message)
         router.push('/auth/login')

--- a/src/app/auth/login/components/LoginForm.tsx
+++ b/src/app/auth/login/components/LoginForm.tsx
@@ -74,12 +74,19 @@ export default function LoginComponent({ locale = 'en', t = defaultT }: LoginCom
   const handleGoogleLogin = async () => {
     setGoogleLoading(true)
     // Always redirect OAuth to /auth/callback, with ?next for final destination
-    const oauthRedirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(postAuthRedirect)}${lang ? `&lang=${lang}` : ''}`
+    const isLocalhost = window.location.hostname === 'localhost'
+    const redirectBase = isLocalhost
+      ? 'https://presu.com.ar'
+      : window.location.origin
+    const nextTarget = isLocalhost
+      ? `${window.location.origin}${postAuthRedirect}`
+      : postAuthRedirect
+    const oauthRedirectTo = `${redirectBase}/auth/callback?next=${encodeURIComponent(nextTarget)}${lang ? `&lang=${lang}` : ''}`
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
-        redirectTo: oauthRedirectTo
-      }
+        redirectTo: oauthRedirectTo,
+      },
     })
     if (error) {
       setError(error.message)

--- a/src/app/auth/register/components/RegisterForm.tsx
+++ b/src/app/auth/register/components/RegisterForm.tsx
@@ -98,10 +98,17 @@ export default function RegisterComponent({ t = defaultT, role = 'client' }: Reg
   const handleGoogleSignup = async () => {
     setGoogleLoading(true)
     // Pass role so the callback/server can persist it
-    const oauthRedirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(postAuthRedirect)}${lang ? `&lang=${lang}` : ''}&role=${effectiveRole}`
+    const isLocalhost = window.location.hostname === 'localhost'
+    const redirectBase = isLocalhost
+      ? 'https://presu.com.ar'
+      : window.location.origin
+    const nextTarget = isLocalhost
+      ? `${window.location.origin}${postAuthRedirect}`
+      : postAuthRedirect
+    const oauthRedirectTo = `${redirectBase}/auth/callback?next=${encodeURIComponent(nextTarget)}${lang ? `&lang=${lang}` : ''}&role=${effectiveRole}`
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
-      options: { redirectTo: oauthRedirectTo }
+      options: { redirectTo: oauthRedirectTo },
     })
     if (error) {
       setError(error.message)


### PR DESCRIPTION
## Summary
- Remove OAuth tokens from callback URL and support external redirects
- Redirect Google OAuth through production domain in dev so callbacks return to localhost

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9c0d8c2c4832690a68cc08200e5db