### PR TITLE
Refactor auth callback to use shared component

### DIFF
--- a/src/app/auth/callback/CallbackBody.tsx
+++ b/src/app/auth/callback/CallbackBody.tsx
@@ -28,7 +28,24 @@ export function CallbackBody() {
             fullName,
           }),
         })
-        router.push(next)
+
+        // Remove tokens and auth params from URL after session is stored
+        const params = new URLSearchParams(searchParams.toString())
+        params.delete('code')
+        params.delete('state')
+        window.history.replaceState(
+          {},
+          document.title,
+          `${window.location.pathname}${
+            params.toString() ? `?${params.toString()}` : ''
+          }`
+        )
+
+        if (/^https?:\/\//.test(next)) {
+          window.location.href = next
+        } else {
+          router.push(next)
+        }
       } else {
         console.error('Recovery failed:', error?.message)
         router.push('/auth/login')
@@ -36,6 +53,7 @@ export function CallbackBody() {
     }
 
     recover()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router]) // don't include searchParams, it’s a new object each render
 
   return <div className="p-6 text-center text-gray-200">Restaurando sesión...</div>

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,59 +1,8 @@
 'use client'
-import { useEffect } from 'react'
-import { supabase } from '@/lib/supabaseClient'
-import { useRouter } from 'next/navigation'
+
+import { CallbackBody } from './CallbackBody'
 
 export default function CallbackPage() {
-  const router = useRouter()
-
-  useEffect(() => {
-    const recover = async () => {
-      const urlParams = new URLSearchParams(window.location.search)
-      const role = urlParams.get('role') || undefined
-      const nextParam = urlParams.get('next')
-      const next = nextParam ? decodeURIComponent(nextParam) : '/'
-
-      const { data, error } = await supabase.auth.getSession()
-      if (data.session) {
-        const fullName =
-          data.session.user.user_metadata?.full_name ||
-          data.session.user.user_metadata?.name
-
-        await fetch('/api/create-user-folder', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            userId: data.session.user.id,
-            role,
-            fullName,
-          }),
-        })
-
-        // Remove tokens and auth params from URL after session is stored
-        const params = new URLSearchParams(window.location.search)
-        params.delete('code')
-        params.delete('state')
-        window.history.replaceState(
-          {},
-          document.title,
-          `${window.location.pathname}${
-            params.toString() ? `?${params.toString()}` : ''
-          }`
-        )
-
-        if (/^https?:\/\//.test(next)) {
-          window.location.href = next
-        } else {
-          router.push(next)
-        }
-      } else {
-        console.error('Recovery failed:', error?.message)
-        router.push('/auth/login')
-      }
-    }
-
-    recover()
-  }, [router])
-
-  return <div className="p-6 text-center text-gray-200">Restaurando sesión...</div>
+  return <CallbackBody />
 }
+


### PR DESCRIPTION
## Summary
- consolidate auth callback logic in `CallbackBody` and strip tokens from URL
- simplify callback page to render shared body component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9d245a0508326a862585faa1e9019