### PR TITLE
Place provider join option beneath user info in side menu

### DIFF
--- a/src/components/layout/SideMenu.tsx
+++ b/src/components/layout/SideMenu.tsx
@@ -144,6 +144,19 @@ export default function SideMenu({
                   <p className="text-sm text-gray-500">{user.email}</p>
                 </div>
               </div>
+              <ul className="px-4 pt-6 font-semibold">
+                <li>
+                  <button
+                    onClick={() => {
+                      router.push(`/auth/register?role=pro&lang=${locale}`)
+                      onClose()
+                    }}
+                    className="w-full text-center text-base py-2"
+                  >
+                    {providerLabel}
+                  </button>
+                </li>
+              </ul>
               {/* Mobile user actions */}
               <ul className="md:hidden px-4 pt-6 flex flex-col gap-2">
                 <li>
@@ -238,23 +251,21 @@ export default function SideMenu({
               >
                 {t.login}
               </button>
+              <ul className="px-4 pt-6 font-semibold">
+                <li>
+                  <button
+                    onClick={() => {
+                      router.push(`/auth/register?role=pro&lang=${locale}`)
+                      onClose()
+                    }}
+                    className="w-full text-center text-base py-2"
+                  >
+                    {providerLabel}
+                  </button>
+                </li>
+              </ul>
             </>
           )}
-
-          {/* Additional Options */}
-          <ul className="space-y-4 font-semibold mt-auto pt-6">
-            <li>
-              <button
-                onClick={() => {
-                  router.push(`/auth/register?role=pro&lang=${locale}`)
-                  onClose()
-                }}
-                className="w-full text-center text-base py-2"
-              >
-                {providerLabel}
-              </button>
-            </li>
-          </ul>
         </div>
       </div>
     </>


### PR DESCRIPTION
## Summary
- Show "Join as a provider" directly under the username in the side menu
- Keep provider option accessible for logged-out users too

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9d2f6bb688326be93a8b37973f9b8