### PR TITLE
Align search service list order with services page

### DIFF
--- a/src/app/services/ServicesClient.tsx
+++ b/src/app/services/ServicesClient.tsx
@@ -7,7 +7,7 @@ import Footer from '@/components/layout/Footer'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabaseClient'
 import type { Service } from '@/lib/serviceCatalog'
-import { upcomingServices } from '@/lib/serviceCatalog'
+import { upcomingServices, serviceOrder } from '@/lib/serviceCatalog'
 import { getFooterTranslations } from '@/lib/footerTranslations'
 
 export default function ServicesClient() {
@@ -53,18 +53,8 @@ export default function ServicesClient() {
 
       const fetched = (data ?? []) as Service[]
 
-      const order = [
-        'security',
-        'cleaning',
-        'fumigation',
-        'elevator-maintenance',
-        'notary',
-        'community-manager',
-        'transfers',
-        'kids-party-venues'
-      ]
       const orderMap: Record<string, number> = {}
-      order.forEach((slug, index) => {
+      serviceOrder.forEach((slug, index) => {
         orderMap[slug] = index
       })
 

--- a/src/components/sections/home/HeroSection.tsx
+++ b/src/components/sections/home/HeroSection.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from 'react'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabaseClient'
-import { Service, upcomingServices } from '@/lib/serviceCatalog'
+import { Service, upcomingServices, serviceOrder } from '@/lib/serviceCatalog'
 
 const heroImages = [
   '/images/hero-section/card-01.jpg',
@@ -44,7 +44,14 @@ export default function HeroSection({ t, userAddress, locale }: HeroProps) {
 
       if (data) {
         const enabled = data.map((s) => ({ ...s, image_url: '', disabled: false }))
-        setServices([...enabled, ...upcomingServices])
+        const orderMap: Record<string, number> = {}
+        serviceOrder.forEach((slug, index) => {
+          orderMap[slug] = index
+        })
+        const sorted = [...enabled].sort(
+          (a, b) => (orderMap[a.slug] ?? Infinity) - (orderMap[b.slug] ?? Infinity)
+        )
+        setServices([...sorted, ...upcomingServices])
       } else {
         setServices(upcomingServices)
       }

--- a/src/lib/serviceCatalog.ts
+++ b/src/lib/serviceCatalog.ts
@@ -8,6 +8,17 @@ export type Service = {
   disabled?: boolean;
 };
 
+export const serviceOrder = [
+  'security',
+  'cleaning',
+  'fumigation',
+  'elevator-maintenance',
+  'notary',
+  'community-manager',
+  'transfers',
+  'kids-party-venues',
+];
+
 export const upcomingServices: Service[] = [
   {
     slug: 'auditing',


### PR DESCRIPTION
## Summary
- centralize service order in `serviceCatalog` and apply to /services page
- sort search suggestions in hero section using same service order

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb12bb575c8326bdc58c45176dc3fb