### PR TITLE
Add WhatsApp social link to footer

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image'
 import Link from 'next/link'
+import { FaWhatsapp } from 'react-icons/fa'
 
 type FooterProps = {
   t: {
@@ -14,6 +15,10 @@ type FooterProps = {
 }
 
 export default function Footer({ t, locale }: FooterProps) {
+  const whatsappMessage = encodeURIComponent(
+    'Hola Presu, me gustaría obtener más información sobre sus servicios.'
+  )
+
   return (
     <footer className="bg-gray-50 border-t text-gray-600 text-sm px-6 py-10">
       <div className="max-w-3xl mx-auto flex flex-col items-center text-center gap-4">
@@ -60,12 +65,33 @@ export default function Footer({ t, locale }: FooterProps) {
 
         {/* Social Icons */}
         <div className="flex gap-4 text-gray-500 mt-2">
-          <a href="https://instagram.com/presu_arg" className="hover:text-red-500" aria-label="Instagram" target="_blank" rel="noopener noreferrer">
+          <a
+            href="https://instagram.com/presu_arg"
+            className="hover:text-red-500"
+            aria-label="Instagram"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 448 512">
               <path d="M224.1 141c-63.6 0-115.1 51.5-115.1 115.1S160.5 371.2 224.1 371.2 339.2 319.7 339.2 256 287.7 141 224.1 141zm0 190.2c-41.5 0-75.1-33.6-75.1-75.1s33.6-75.1 75.1-75.1 75.1 33.6 75.1 75.1-33.6 75.1-75.1 75.1zm146.4-194.3c0 14.9-12 26.9-26.9 26.9s-26.9-12-26.9-26.9 12-26.9 26.9-26.9 26.9 12 26.9 26.9zm76.1 27.2c-.9-19.6-5.2-37-19.1-51C405.2 90.3 387.7 86 368.1 85.1c-27.2-1.2-108.9-1.2-136.1 0-19.6.9-37 5.2-51 19.1s-18.2 31.4-19.1 51c-1.2 27.2-1.2 108.9 0 136.1.9 19.6 5.2 37 19.1 51s31.4 18.2 51 19.1c27.2 1.2 108.9 1.2 136.1 0 19.6-.9 37-5.2 51-19.1s18.2-31.4 19.1-51c1.2-27.2 1.2-108.9 0-136.1zM398.8 388c-7.8 19.5-22.9 34.6-42.4 42.4-29.4 11.7-99.2 9-132.4 9s-103 .7-132.4-9c-19.5-7.8-34.6-22.9-42.4-42.4-11.7-29.4-9-99.2-9-132.4s-.7-103 9-132.4c7.8-19.5 22.9-34.6 42.4-42.4C121.6 58.2 191.4 60.9 224.6 60.9s103-.7 132.4 9c19.5 7.8 34.6 22.9 42.4 42.4 11.7 29.4 9 99.2 9 132.4s.6 103-9 132.4z"/>
             </svg>
           </a>
-          <a href="https://www.linkedin.com/company/presu" className="hover:text-red-500" aria-label="LinkedIn" target="_blank" rel="noopener noreferrer">
+          <a
+            href={`https://wa.me/5491168112344?text=${whatsappMessage}`}
+            className="hover:text-red-500"
+            aria-label="WhatsApp"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <FaWhatsapp className="w-5 h-5" />
+          </a>
+          <a
+            href="https://www.linkedin.com/company/presu"
+            className="hover:text-red-500"
+            aria-label="LinkedIn"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 448 512">
               <path d="M100.28 448H7.4V148.9h92.88zm-46.44-340c-29.7 0-53.74-24.15-53.74-53.74C0 24.15 24.04 0 53.84 0s53.74 24.15 53.74 53.74c-.01 29.59-24.05 53.74-53.74 53.74zM447.9 448h-92.4V302.4c0-34.7-12.5-58.4-43.6-58.4-23.8 0-38.1 16-44.3 31.4-2.3 5.5-2.8 13.2-2.8 20.9V448h-92.6s1.2-270.4 0-298.1h92.6v42.3c-.2.3-.5.7-.7 1h.7v-1c12.3-18.9 34.4-45.8 83.7-45.8 61.2 0 107.1 39.9 107.1 125.5V448z"/>
             </svg>


### PR DESCRIPTION
## Summary
- add WhatsApp message link beside Instagram in footer
- encode preset message like Help UI

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb12ffcf688326a84b196857d0b532