### PR TITLE
Replace service rating with provider count KPI

### DIFF
--- a/src/app/services/ServicesClient.tsx
+++ b/src/app/services/ServicesClient.tsx
@@ -36,7 +36,7 @@ export default function ServicesClient() {
   const t = {
     availableTitle: locale === 'es' ? 'Servicios disponibles' : 'Available Services',
     upcomingTitle: locale === 'es' ? 'Servicios próximos' : 'Upcoming Services',
-    rating: locale === 'es' ? 'puntuación' : 'rating',
+    providers: locale === 'es' ? 'proveedores' : 'providers',
     schedule: locale === 'es' ? 'Horario estimado' : 'Estimated hours',
   }
 
@@ -111,10 +111,10 @@ export default function ServicesClient() {
 
         <div className="px-3 py-2">
           <h3 className="font-medium text-sm truncate">{name}</h3>
-          {(s.rating || s.schedule) && (
+          {(s.provider_count || s.schedule) && (
             <p className="text-xs text-gray-600">
-              {s.rating ? `⭐ ${s.rating}` : ''}
-              {s.rating && s.schedule ? ' • ' : ''}
+              {s.provider_count ? `${s.provider_count} ${t.providers}` : ''}
+              {s.provider_count && s.schedule ? ' • ' : ''}
               {s.schedule || ''}
             </p>
           )}

--- a/src/app/services/[service]/ServiceFormClient.tsx
+++ b/src/app/services/[service]/ServiceFormClient.tsx
@@ -137,64 +137,56 @@ const serviceInfo = {
     enName: 'Private Security',
     esDesc: 'Protección integral para hogares y negocios.',
     enDesc: 'Comprehensive protection for homes and businesses.',
-    image: '/images/services/security.jpg',
-    rating: '4.8'
+    image: '/images/services/security.jpg'
   },
   cleaning: {
     esName: 'Limpieza Profesional',
     enName: 'Professional Cleaning',
     esDesc: 'Servicios de limpieza detallados para cualquier espacio.',
     enDesc: 'Detailed cleaning services for any space.',
-    image: '/images/services/cleaning.jpg',
-    rating: '4.7'
+    image: '/images/services/cleaning.jpg'
   },
   fumigation: {
     esName: 'Fumigación a domicilio',
     enName: 'Home Fumigation',
     esDesc: 'Eliminación de plagas con técnicas seguras.',
     enDesc: 'Pest removal with safe techniques.',
-    image: '/images/services/fumigation.jpg',
-    rating: '4.6'
+    image: '/images/services/fumigation.jpg'
   },
   'elevator-maintenance': {
     esName: 'Mantenimiento de ascensores',
     enName: 'Elevator Maintenance',
     esDesc: 'Mantenimiento preventivo y correctivo de ascensores.',
     enDesc: 'Preventive and corrective elevator maintenance.',
-    image: '/images/services/elevator_maintenance.jpg',
-    rating: '4.5'
+    image: '/images/services/elevator_maintenance.jpg'
   },
   notary: {
     esName: 'Escribanía',
     enName: 'Notary Services',
     esDesc: 'Gestiones notariales con profesionales matriculados.',
     enDesc: 'Notarial procedures by licensed professionals.',
-    image: '/images/services/notary.jpg',
-    rating: '4.7'
+    image: '/images/services/notary.jpg'
   },
   'community-manager': {
     esName: 'Community Manager',
     enName: 'Community Manager',
     esDesc: 'Gestión de redes sociales para tu marca.',
     enDesc: 'Social media management for your brand.',
-    image: '/images/services/community.jpg',
-    rating: '4.5'
+    image: '/images/services/community.jpg'
   },
   'transfers': {
     esName: 'Traslados Ejecutivos',
     enName: 'Executive Transfers',
     esDesc: 'Transporte ejecutivo cómodo y seguro.',
     enDesc: 'Comfortable and safe executive transport.',
-    image: '/images/services/transfer.jpg',
-    rating: '4.8'
+    image: '/images/services/transfer.jpg'
   },
   'kids-party-venues': {
     esName: 'Salones Infantiles',
     enName: 'Kids Party Venues',
     esDesc: 'Espacios ideales para fiestas infantiles.',
     enDesc: 'Ideal spaces for kids parties.',
-    image: '/images/services/kids-party.jpg',
-    rating: '4.6'
+    image: '/images/services/kids-party.jpg'
   }
 } as const
 
@@ -237,6 +229,7 @@ export default function ServiceFormClient({ service }: Props) {
   const [invoiceError, setInvoiceError] = useState('')
   const [error, setError] = useState('')
   const [submitted, setSubmitted] = useState(false)
+  const [providerCount, setProviderCount] = useState(0)
   const user = useUser()
 
   const isSeguridad = service.toLowerCase() === 'security'
@@ -249,9 +242,20 @@ export default function ServiceFormClient({ service }: Props) {
       enName: service,
       esDesc: '',
       enDesc: '',
-      image: '',
-      rating: ''
+      image: ''
     }
+
+  useEffect(() => {
+    const fetchCount = async () => {
+      const { data } = await supabase
+        .from('services')
+        .select('provider_count')
+        .eq('slug', service)
+        .single()
+      setProviderCount(data?.provider_count || 0)
+    }
+    fetchCount()
+  }, [service])
 
   useEffect(() => {
     if (isSeguridad) {
@@ -413,8 +417,13 @@ export default function ServiceFormClient({ service }: Props) {
               <h1 className="text-2xl font-bold mb-4">
                 {locale === 'es' ? info.esName : info.enName}
               </h1>
-              {info.rating && (
-                <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">⭐ {info.rating}</p>
+              {providerCount > 0 && (
+                <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+                  {providerCount}{' '}
+                  {locale === 'es'
+                    ? 'proveedores en cartera'
+                    : 'providers in portfolio'}
+                </p>
               )}
               <p className="text-sm text-gray-600 dark:text-gray-300 mb-6">
                 {locale === 'es' ? info.esDesc : info.enDesc}

--- a/src/lib/serviceCatalog.ts
+++ b/src/lib/serviceCatalog.ts
@@ -3,7 +3,7 @@ export type Service = {
   name_es: string;
   name_en: string;
   image_url: string;
-  rating?: number;
+  provider_count?: number;
   schedule?: string;
   disabled?: boolean;
 };

--- a/supabase/services.sql
+++ b/supabase/services.sql
@@ -7,40 +7,43 @@ create table if not exists reference.services (
   slug text unique,
   name_es text,
   name_en text,
-  rating numeric,
+  base_providers integer default 0,
   schedule text,
   image_url text
 );
 
--- Insert initial service records
-insert into reference.services (slug, name_es, name_en, rating, image_url) values
-  ('seguridad', 'Seguridad privada', 'Private Security', 4.8, '/images/services/security.jpg'),
-  ('limpieza', 'Limpieza Profesional', 'Professional Cleaning', 4.7, '/images/services/cleaning.jpg'),
-  ('fumigacion', 'Fumigación a domicilio', 'Home Fumigation', 4.6, '/images/services/fumigation.jpg'),
-  ('mantenimiento-ascensores', 'Mantenimiento de ascensores', 'Elevator Maintenance', 4.5, '/images/services/elevator_maintenance.jpg'),
-  ('escribania', 'Escribanía', 'Notary Services', 4.7, '/images/services/notary.jpg'),
-  ('community-manager', 'Community Manager', 'Community Manager', 4.5, '/images/services/community.jpg'),
-  ('traslados-ejecutivos', 'Traslados Ejecutivos', 'Executive Transfers', 4.8, '/images/services/transfer.jpg'),
-  ('salones-infantiles', 'Salones Infantiles', 'Kids Party Venues', 4.6, '/images/services/kids-party.jpg')
-  on conflict (slug) do update set
-    name_es = excluded.name_es,
-    name_en = excluded.name_en,
-    rating = excluded.rating,
-    image_url = excluded.image_url;
+-- Insert initial service records with base provider counts
+insert into reference.services (slug, name_es, name_en, base_providers, image_url) values
+  ('security', 'Seguridad privada', 'Private Security', 10, '/images/services/security.jpg'),
+  ('cleaning', 'Limpieza Profesional', 'Professional Cleaning', 7, '/images/services/cleaning.jpg'),
+  ('fumigation', 'Fumigación a domicilio', 'Home Fumigation', 0, '/images/services/fumigation.jpg'),
+  ('elevator-maintenance', 'Mantenimiento de ascensores', 'Elevator Maintenance', 0, '/images/services/elevator_maintenance.jpg'),
+  ('notary', 'Escribanía', 'Notary Services', 0, '/images/services/notary.jpg'),
+  ('community-manager', 'Community Manager', 'Community Manager', 0, '/images/services/community.jpg'),
+  ('transfers', 'Traslados Ejecutivos', 'Executive Transfers', 0, '/images/services/transfer.jpg'),
+  ('kids-party-venues', 'Salones Infantiles', 'Kids Party Venues', 0, '/images/services/kids-party.jpg')
+on conflict (slug) do update set
+  name_es = excluded.name_es,
+  name_en = excluded.name_en,
+  base_providers = excluded.base_providers,
+  image_url = excluded.image_url;
 
 -- Exposed view in the api schema
 create schema if not exists api;
 create or replace view api.services as
-  select 
-    services.id,
-    services.slug,
-    services.name_en,
-    services.name_es,
-    services.rating,
-    services.schedule,
-    services.image_url
-  from reference.services;
+  select
+    s.id,
+    s.slug,
+    s.name_en,
+    s.name_es,
+    s.base_providers + coalesce(count(ps.provider_id), 0) as provider_count,
+    s.schedule,
+    s.image_url
+  from reference.services s
+  left join api.provider_services ps on ps.service_id = s.id
+  group by s.id, s.slug, s.name_en, s.name_es, s.base_providers, s.schedule, s.image_url;
 
 -- Allow read access to the view for anonymous and authenticated users
 grant usage on schema api to anon, authenticated, service_role;
 grant select on api.services to anon, authenticated, service_role;
+


### PR DESCRIPTION
## Summary
- track baseline provider counts per service and compute total providers in `api.services`
- show provider portfolio count instead of ratings on service list and request pages
- update Service type to include `provider_count`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb14578b448326bb259ca0cbf2b232