### PR TITLE
feat: dismiss hero search suggestions on escape or blur

### DIFF
--- a/src/components/sections/home/HeroSection.tsx
+++ b/src/components/sections/home/HeroSection.tsx
@@ -218,6 +218,13 @@ export default function HeroSection({ t, userAddress, locale }: HeroProps) {
                   setSearchTerm(e.target.value)
                   setShowSuggestions(true)
                 }}
+                onBlur={() => setShowSuggestions(false)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Escape') {
+                    setShowSuggestions(false)
+                    searchInputRef.current?.blur()
+                  }
+                }}
               />
               <button className="ml-2 p-2 rounded-full hover:bg-gray-100 transition">
                 <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5 text-gray-500" viewBox="0 0 256 256" fill="currentColor">
@@ -260,6 +267,13 @@ export default function HeroSection({ t, userAddress, locale }: HeroProps) {
                 onChange={(e) => {
                   setSearchTerm(e.target.value)
                   setShowSuggestions(true)
+                }}
+                onBlur={() => setShowSuggestions(false)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Escape') {
+                    setShowSuggestions(false)
+                    searchInputRef.current?.blur()
+                  }
                 }}
               />
               {renderSuggestions()}


### PR DESCRIPTION
## Summary
- close hero section suggestions when the input loses focus
- hide suggestions on Escape key press for better keyboard navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb1596386883269bc3a0509ee0f2c6